### PR TITLE
Update magik-lint.el

### DIFF
--- a/magik-lint.el
+++ b/magik-lint.el
@@ -21,7 +21,7 @@
 
 (require 'flycheck)
 
-(defcustom magik-lint-jar-file (expand-file-name (concat user-emacs-directory "magik-lint/magik-lint-0.3.2.jar"))
+(defcustom magik-lint-jar-file (expand-file-name (concat user-emacs-directory "magik-lint/magik-lint.jar"))
   "Location of the magik-lint jar file."
   :group 'magik
   :type  '(choice (file)


### PR DESCRIPTION
Remove version from jar so we always can use the latest version