### PR TITLE
magik-session-kill-line no longer ignores arg

### DIFF
--- a/magik-session.el
+++ b/magik-session.el
@@ -1197,7 +1197,7 @@ range [MIN, MAX)."
   "Take a copy of a command before killing the line."
   (interactive "*P")
   (magik-session--prepare-for-edit-cmd)
-  (kill-line))
+  (kill-line arg))
 
 (defun magik-session-kill-region (beg end)
   "Ask if they really want to kill the region, before killing it."


### PR DESCRIPTION
A colleague of mine, who startet using magik but has had long experience with EMACS, was irritated that a prefix argument (e.g. given by C-u) has no influence for the <kbd>Ctrl</kbd><kbd>k</kbd> (`magik-session-kill-line`) command within the magik-session-mode. In fact it is a bit strange, that of all these `magik-session-(do any simple edit)` functions this is the only one, which doesn't pass the `arg` do the simple edit function (The same holds for the previously with SW 4.x or earlier delivered EMACS versions).

So one can think about the reason. 

There might be a connection to the question the user sees when calling `magik-session-kill-region`

> Cutting and pasting big regions can confuse the gis-mode markers. Kill anyway?

On the other hand, I never had seen great problems with that, and I don't think it's too dangerous to kill several lines with one command.

Dear maintainers, you might come to a different conclusion, which I'd be happy to read about, if you don't integrate my change.

Thanks
ReinhardHahn