### PR TITLE
improve magik-version-read-smallworld-gis

### DIFF
--- a/magik-version.el
+++ b/magik-version.el
@@ -264,8 +264,9 @@ suitable for selection."
   "Prompt for a valid value for SMALLWORLD_GIS."
   (let ((path
 	 (file-truename (read-directory-name "Enter product directory for Core installation: "))))
-    (setq path (directory-file-name (file-name-directory path)))
-    (subst-char-in-string ?/ ?\\ path t)
+    (setq path (directory-file-name path))
+    (if (eq system-type 'windows-nt)
+	(subst-char-in-string ?/ ?\\ path t))
     path))
 
 (defun magik-version-file-add (root name version)


### PR DESCRIPTION
* prior to that change last directory element has been omitted when adding a new gis version, which was quite irritating to the user
* under GNU/Linux: in GIS-Version directory no longer '/' is replaced by '\'