### PR TITLE
Added some hints to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ Major mode for running Magik session as a direct sub-process.
 
 Major prog mode for editing Magik code.
 
+Support for outline-minor mode. Try e.g.:
+(add-hook 'magik-mode-hook
+	  (lambda ()
+	    (setq outline-regexp magik-mode-outline-string-regexp)))
+
+Support for imenu. Try e.g.:
+(add-hook 'magik-mode-hook 'imenu-add-menubar-index)
+
+
 ### magik-electric-mode
 
 Minor mode for electic Magik.

--- a/README.md
+++ b/README.md
@@ -51,9 +51,7 @@ Major mode for running Magik session as a direct sub-process.
 Major prog mode for editing Magik code.
 
 Support for outline-minor mode. Try e.g.:
-(add-hook 'magik-mode-hook
-	  (lambda ()
-	    (setq outline-regexp magik-mode-outline-string-regexp)))
+(outline-minor-mode)
 
 Support for imenu. Try e.g.:
 (add-hook 'magik-mode-hook 'imenu-add-menubar-index)

--- a/README.md
+++ b/README.md
@@ -79,3 +79,10 @@ To enable automatic linting in `magik-mode` buffers, the following conditions ha
 * `magik-lint-VERSION.jar` ([download](https://github.com/StevenLooman/sonar-magik/releases)) has to be installed in `~/.emacs.d/magik-lint/` (location can be customized with the variable `magik-lint-jar-file`).
 * The `java` executable path should be in `exec-path`, or the variable `flycheck-magik-lint-java-executable` has to be set. `flycheck-magik-lint-java-executable` will automatically be set when the environment variable `JAVA_HOME` is set.
 * `flycheck-mode` has to be enabled for `magik-mode` buffers. Or use `global-flycheck-mode` to enable it for all buffers.
+
+## Usage with Smallworld 4.x or older
+
+If you plan to use this package with Smallworld-Versions 4.x or older, you should consider the following points:
+* Customize the variable `magik-session-auto-insert-dollar` to non nil
+* You might customize the variable `magik-aliases-layered-products-file` to "$SMALLWORLD_GIS/product/config/LAYERED_PRODUCTS". But if you want to use the EMACS for Smallworld 5.x as well, it's easier to create the directory `$SMALLWORLD_GIS/../smallworld_registry` and copy or soft-link the original LAYERED_PRODUCTS file into that directory - so you have the same structure as under Smallworld 5.x.
+* There is no support for the Smallworld 4.x dev-tools. So if you want to do things like <kbd>f4</kbd><kbd>d</kbd> to start debugging a method, you have to use the EMACS which has been delivered with the Smallworld 4.x (or older) software.

--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ To enable automatic linting in `magik-mode` buffers, the following conditions ha
 If you plan to use this package with Smallworld-Versions 4.x or older, you should consider the following points:
 * Customize the variable `magik-session-auto-insert-dollar` to non nil
 * You might customize the variable `magik-aliases-layered-products-file` to "$SMALLWORLD_GIS/product/config/LAYERED_PRODUCTS". But if you want to use the EMACS for Smallworld 5.x as well, it's easier to create the directory `$SMALLWORLD_GIS/../smallworld_registry` and copy or soft-link the original LAYERED_PRODUCTS file into that directory - so you have the same structure as under Smallworld 5.x.
-* There is no support for the Smallworld 4.x dev-tools. So if you want to do things like <kbd>f4</kbd><kbd>d</kbd> to start debugging a method, you have to use the EMACS which has been delivered with the Smallworld 4.x (or older) software.
+* There is no support (yet) for the Smallworld dev-tools. So if you want to do things like <kbd>f4</kbd><kbd>d</kbd> to start debugging a method, you may still want to use the EMACS which has been delivered with the Smallworld 4.x (or older) software.


### PR DESCRIPTION
* Hint usage of outline-minor-mode with magik-files
* Hint for usage of imenu with magik-Files
* Hints for usage with Smallworld 4.x (Although with Smallworld 4.x an EMACS has been delivered, which works well, there might be several reasons to use the MELPA package not only for Smallworld 5.x but also for older Smallworld versions. I've added a few things worth to be mentioned).