### PR TITLE
input of gis-version line foolproof: prevent input of spaces in name …

### DIFF
--- a/magik-version.el
+++ b/magik-version.el
@@ -286,8 +286,8 @@ suitable for selection."
 	   (setq version (current-word)
 		 name    version)))
      (list root
-	   (read-string "Enter name for this installation: " name)
-	   (read-string "Enter version number of this installation: " version))))
+	   (read-no-blanks-input "Enter name for this installation: " name)
+	   (read-no-blanks-input "Enter version number of this installation: " version))))
 
   (or magik-version-file
       (error "File interface is not being used"))


### PR DESCRIPTION
…or version

Without this change it could happen, that a user chooses a name or version which include a space character - which doesn't yield to a valid gis_version.txt-entry as the software interprets white space as delimiter between the parts 'name', 'version' and 'SMALLWORLD_GIS-directory'.

So the change prevents the user from trying such an invalid naming convention.