### PR TITLE
mf Variable substitution didn't work under GNU/Linux

### DIFF
--- a/magik-cb.el
+++ b/magik-cb.el
@@ -2341,17 +2341,21 @@ See the variable `magik-cb-generalise-file-name-alist' to provide more customisa
 		   if (and (string-match (car i) f)
 			   (setq f (replace-match (cdr i) nil t f)))
 		   return f)))
-    (progn
-      (subst-char-in-string ?/ ?\\ f t)
-      (if (or (string-match "^[a-zA-Z]:" f)
-	      (string-match "^\\\\\\\\" f))
-	  f
-	(let* ((buffer (magik-cb-gis-buffer))
-	       (drive-name (if (get-buffer buffer)
-			       (with-current-buffer buffer
-				 (substring default-directory 0 2))
-			     (substring default-directory 0 2))))
-	  (concat drive-name f))))))
+    (if (eq system-type 'windows-nt)
+	(progn
+	  (subst-char-in-string ?/ ?\\ f t)
+	  (if (or (string-match "^[a-zA-Z]:" f)
+		  (string-match "^\\\\\\\\" f))
+	      f
+	    (let* ((buffer (magik-cb-gis-buffer))
+		   (drive-name (if (get-buffer buffer)
+				   (with-current-buffer buffer
+				     (substring default-directory 0 2))
+				 (substring default-directory 0 2))))
+	      (concat drive-name f))))
+      (if (string-match "^[a-zA-Z]:" f)
+	  (setq f (substring f 2)))
+      (subst-char-in-string ?\\ ?/ f t))))
 
 ;;Package configuration
 (magik-cb-set-mode-line-cursor magik-cb-mode-line-cursor)


### PR DESCRIPTION
The mf files for the method finder, which are delivered by GE for many entries contain the $SMALLWORLD_GIS variable as part of the path to the magik file. Although the sources of these magik files normally are not delivered, there is no reason to not expand this variable under GNU/Linux as well (like it works under Windows). So the change restores the functionality of the former EMACS delivered with the SW 4.x installation.