### PR TITLE
Fix broken menu entries etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,11 @@ Some keys bindings are changed with respect to a standard EMACS installation, at
 | <kbd>F2</kbd> | `2C-command`|globally changed to prefix key |
 | <kbd>F3</kbd> | `kmacro-start-macro-or-insert-counter` | globally changed to prefix key |
 | <kbd>F4</kbd> | `kmacro-end-or-call-macro` | used in magik-mode and magik-session-mode as prefix key |
+
+The reason for that is, that many Magik developpers are familiar with these bindings from former EMACS installations.
+
+For quick usage of the keyboard-macro functions you may e.g. bind the <kbd>Ctrl</kbd>-<kbd>F2</kbd> and <kbd>Ctrl</kbd>-<kbd>F4</kbd> combinations by putting the following lines into your  `.emacs` file:
+``` emacs-lisp
+(global-set-key [C-f3] 'kmacro-start-macro-or-insert-counter)
+(global-set-key [C-f4] 'kmacro-end-or-call-macro)
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # magik-mode: Emacs major mode for Smallworld Magik files
 
+## Content
+1. [Installation](#installation)
+2. [Features](#features)
+3. [Usage with Smallworld 4.x or older](#usage4x)
+4. [Side Effects](#sideeffects)
+
 ## Installation
 
 These packages are available on [MELPA](https://melpa.org/). 
@@ -23,6 +29,8 @@ Global keys are set by calling `(magik-global-bindings)` after the packages has 
 | Key | Description |
 | :---: | --- |
 |<kbd>F2</kbd><kbd>s</kbd> | Open Magik version selection |
+
+
 
 ### magik-version
 
@@ -85,10 +93,20 @@ To enable automatic linting in `magik-mode` buffers, the following conditions ha
 * The `java` executable path should be in `exec-path`, or the variable `flycheck-magik-lint-java-executable` has to be set. `flycheck-magik-lint-java-executable` will automatically be set when the environment variable `JAVA_HOME` is set.
 * `flycheck-mode` has to be enabled for `magik-mode` buffers. Or use `global-flycheck-mode` to enable it for all buffers.
 
-## Usage with Smallworld 4.x or older
+## <a name="usage4x"></a>Usage with Smallworld 4.x or older
 
 If you plan to use this package with Smallworld-Versions 4.x or older, you should consider the following points:
 * Customize the variable `magik-session-auto-insert-dollar` to non nil
 * You might customize the variable `magik-aliases-layered-products-file` to "$SMALLWORLD_GIS/product/config/LAYERED_PRODUCTS". But if you want to use the EMACS for Smallworld 5.x as well, it's easier to create the directory `$SMALLWORLD_GIS/../smallworld_registry` and copy or soft-link the original LAYERED_PRODUCTS file into that directory - so you have the same structure as under Smallworld 5.x.
 * There is no support (yet) for the Smallworld dev-tools. So if you want to do things like <kbd>f4</kbd><kbd>d</kbd> to start debugging a method, you may still want to use the EMACS which has been delivered with the Smallworld 4.x (or older) software.
 * Some more things which are at least partly not supported by Smallworld 5.x are not supported (e.g. `deep-print`)
+
+## <a name="sideeffects"></a>Side Effects
+
+Some keys bindings are changed with respect to a standard EMACS installation, at least when using `(magik-global-bindings)`:
+
+| Key | Function in standard EMACS | Change in Magik Mode package |
+| :---: | --- | --- |
+| <kbd>F2</kbd> | `2C-command`|globally changed to prefix key |
+| <kbd>F3</kbd> | `kmacro-start-macro-or-insert-counter` | globally changed to prefix key |
+| <kbd>F4</kbd> | `kmacro-end-or-call-macro` | used in magik-mode and magik-session-mode as prefix key |

--- a/README.md
+++ b/README.md
@@ -50,11 +50,9 @@ Major mode for running Magik session as a direct sub-process.
 
 Major prog mode for editing Magik code.
 
-Support for outline-minor mode. Try e.g.:
-(outline-minor-mode)
+Support for outline-minor mode. Try: `(outline-minor-mode)`
 
-Support for imenu. Try e.g.:
-(add-hook 'magik-mode-hook 'imenu-add-menubar-index)
+Support for imenu. Try: `(add-hook 'magik-mode-hook 'imenu-add-menubar-index)`
 
 
 ### magik-electric-mode
@@ -93,3 +91,4 @@ If you plan to use this package with Smallworld-Versions 4.x or older, you shoul
 * Customize the variable `magik-session-auto-insert-dollar` to non nil
 * You might customize the variable `magik-aliases-layered-products-file` to "$SMALLWORLD_GIS/product/config/LAYERED_PRODUCTS". But if you want to use the EMACS for Smallworld 5.x as well, it's easier to create the directory `$SMALLWORLD_GIS/../smallworld_registry` and copy or soft-link the original LAYERED_PRODUCTS file into that directory - so you have the same structure as under Smallworld 5.x.
 * There is no support (yet) for the Smallworld dev-tools. So if you want to do things like <kbd>f4</kbd><kbd>d</kbd> to start debugging a method, you may still want to use the EMACS which has been delivered with the Smallworld 4.x (or older) software.
+* Some more things which are at least partly not supported by Smallworld 5.x are not supported (e.g. `deep-print`)

--- a/magik-cb.el
+++ b/magik-cb.el
@@ -327,7 +327,7 @@ This will stop the \"Loading documentation...\" message from hanging around.")
     [,"Set Options"        magik-cb-edit-topics-and-flags :active t :keys "f3 s, ;"]
     [,"Turn All Topics On/Off"  magik-cb-toggle-all-topics     :active t :keys "f3 t"]
     [,"Reset All Options"          magik-cb-reset                 :active t :keys "f3 r"]
-    [,"Hide"           magik-cb-quit                  :active t :keys "space, f3 h"]
+    [,"Hide"           magik-cb-quit                  :active t :keys "SPC, f3 h"]
     "---"
     [,"Override Flags"
      magik-cb-toggle-override-flags
@@ -358,7 +358,8 @@ This will stop the \"Loading documentation...\" message from hanging around.")
      :keys "f3 $"]
     "---"
     [,"Customize"                      magik-cb-customize             t]
-    [,"Help"                           magik-cb-help                  t]))
+    ;; [,"Help"                           magik-cb-help                  t]
+    ))
 
 (defvar magik-cb--mf-socket-synchronised nil
   "Internal variable for controlling Class Browser processes started from GIS processes.
@@ -664,7 +665,7 @@ To view the help on these variables type C-h v [Return] [variable-name]"
 	buffer-undo-list t
 	font-lock-defaults '(magik-cb-font-lock-keywords nil t ((?_ . "w"))))
 
-  (add-hook 'menu-bar-update-hook 'magik-cb-update-sw-menu)
+  (add-hook 'menu-bar-update-hook 'magik-cb-update-tools-magik-cb-menu)
   (add-hook 'kill-buffer-hook 'magik-cb-buffer-alist-remove nil t) ;local hook
   (run-hooks 'magik-cb-mode-hook))
 
@@ -732,14 +733,14 @@ If `cb-process' is not nil, returns that irrespective of given BUFFER."
 	     (error "No Class Browser is running"))))
     buf))
 
-(defun magik-cb-update-sw-menu ()
-  "Update CB submenu in SW menu bar."
+(defun magik-cb-update-tools-magik-cb-menu ()
+  "Update Class Browser Processes submenu in Tools -> Magik pulldown menu."
   (let ((magik-cb-gis-alist (sort (copy-alist (symbol-value 'magik-session-buffer-alist))
 				  #'(lambda (a b) (< (car a) (car b))))); 1, 2 etc.
 	(magik-cb-alist     (sort (copy-alist magik-cb-buffer-alist); -1, -2, etc.
 				  #'(lambda (a b) (> (car a) (car b)))))
 	cb-list)
-    ;; Order is such that CB of *gis* will be first see gis.el for more details.
+    ;; Order is such that CB of *gis* will be first see magik-session.el for more details.
     (dolist (c magik-cb-alist)
       (let ((i   (- (car c)))
 	    (buf (cdr c)))

--- a/magik-keys.el
+++ b/magik-keys.el
@@ -53,20 +53,20 @@
   (global-set-key (kbd "<f2> #")      'magik-comment-region)
   (global-set-key (kbd "<f2> ESC #")    'magik-uncomment-region)
   (global-set-key (kbd "<f2> b")      'magik-transmit-buffer)
-  (global-set-key (kbd "<f2> h")      'magik-heading)
+  ;; (global-set-key (kbd "<f2> h")      'magik-heading)
   (global-set-key (kbd "<f2> m")      'magik-transmit-method)
   (global-set-key (kbd "<f2> r")      'magik-transmit-region)
-  (global-set-key (kbd "<f2> q")      'fill-magik-public-comment)
+  (global-set-key (kbd "<f2> q")      'magik-fill-public-comment)
   (global-set-key (kbd "<f2> t")      'magik-trace-curr-statement)
 
-  (global-set-key (kbd "<f2> SPC")    'explicit-electric-magik-space)
-  (global-set-key (kbd "<f2> x")      'deep-print)
+  (global-set-key (kbd "<f2> SPC")    'magik-explicit-electric-space)
+  ;; (global-set-key (kbd "<f2> x")      'deep-print)
 
-  (global-set-key (kbd "<f2> <f1>")   'sw-help-keys)
-  (global-set-key (kbd "<f2> [")      'toggle-debug)
+  ;; (global-set-key (kbd "<f2> <f1>")   'sw-help-keys)
+  ;; (global-set-key (kbd "<f2> [")      'toggle-debug)
   (global-set-key (kbd "<f2> TAB")    'hippie-expand)
-  (global-set-key (kbd "<f2> e")      'electric-magik-mode)
-  (global-set-key (kbd "<f2> k")      'sw-reload-dotemacs)
+  (global-set-key (kbd "<f2> e")      'magik-electric-mode)
+  ;; (global-set-key (kbd "<f2> k")      'sw-reload-dotemacs)
   (global-set-key (kbd "<f2> s")      'magik-version-selection)
   (global-set-key (kbd "<f2> z")      'magik-session)
 
@@ -79,7 +79,8 @@
   (global-set-key (kbd "<f3> j")     'magik-cb-jump-to-source)
   (global-set-key (kbd "<f3> m")     'magik-cb-paste-method)
   (global-set-key (kbd "<f3> /")     'magik-cb-and-clear)
-  (global-set-key (kbd "<f3> ?")     'magik-cb-help))
+  ;; (global-set-key (kbd "<f3> ?")     'magik-cb-help)
+  )
 
 (provide 'magik-keys)
 ;;; magik-keys.el ends here

--- a/magik-menu.el
+++ b/magik-menu.el
@@ -41,7 +41,7 @@
     [,"Start new session"             magik-session-new-buffer
      :active t
      :keys "C-u f2 z"]
-    (,"Magik processes")
+    (,"Magik Session Processes")
     "---"
     (,"Class Browser")
     (,"Class Browser Processes")
@@ -77,9 +77,10 @@
     "---"
     [,"Customize"                    magik-cb-customize
      :active t] ;; :key-sequence nil
-    [,"Help"                         magik-cb-help
-     :active t
-     :keys "f3 ?"]))
+    ;; [,"Help"                         magik-cb-help
+    ;;  :active t
+    ;;  :keys "f3 ?"]
+    ))
 
 ;;;###autoload
 (defun magik-menu-set-menus ()
@@ -95,13 +96,13 @@
   ;; Due to a minor bug in easy-menu-change, have to set the "No Process" etc.
   ;; strings separately
   (easy-menu-change (list "Tools" "Magik")
-		    "Magik Processes"
+		    "Magik Session Processes"
 		    (list "No Processes"))
   (easy-menu-change (list "Tools" "Magik")
 		    "Class Browser Processes"
 		    (list "No Processes"))
   (easy-menu-change (list "Tools" "Magik")
-		    "Shell Processes"
+		    "External Shell Processes"
 		    (list "No Processes"))
 
   (easy-menu-change (list "Tools") "--" nil "Search Files (Grep)...")

--- a/magik-mode.el
+++ b/magik-mode.el
@@ -104,19 +104,19 @@ Users can also swap the point and mark positions using \\[exchange-point-and-mar
     [,"Transmit Thing"    magik-transmit-thing          :active (magik-utils-buffer-mode-list 'magik-session-mode)
      :keys "f2 RET"]
     "---"
-    [,"Copy Region to Work Buffer"  magik-copy-region-to-buffer   t] ; FIXME former f4 r
-    [,"Copy Method to Work Buffer"  magik-copy-method-to-buffer   t] ; FIXME former f4 m
-    [,"Set Work Buffer Name"        magik-set-work-buffer-name    t] ; FIXME former f4 n
+    [,"Copy Region to Work Buffer"  magik-copy-region-to-buffer   :active t :keys "f4 r"]
+    [,"Copy Method to Work Buffer"  magik-copy-method-to-buffer   :active t :keys "f4 m"]
+    [,"Set Work Buffer Name"        magik-set-work-buffer-name    :active t :keys "f4 n"]
     "---"
-    [,"Electric Template" magik-explicit-electric-space :active t :keys "f2 SPC"]
-    [,"Mark Method"       magik-mark-method             :active t :keys "C-M-h, f9"]
-    [,"Copy Method"       magik-copy-method             :active t :keys "f6"] ; FIXME former f4 c, f6
-    [,"Compare Method between Windows"   magik-compare-methods         :active t] ; FIXME former f4 w
-    [,"Compare Method using Ediff"     magik-ediff-methods           :active t] ; FIXME former f4 e
+    [,"Electric Template" magik-explicit-electric-space        :active t :keys "f2 SPC"]
+    [,"Mark Method"       magik-mark-method                    :active t :keys "C-M-h, f9"]
+    [,"Copy Method"       magik-copy-method                    :active t :keys "f4 c, f6"]
+    [,"Compare Method between Windows"   magik-compare-methods :active t :keys "f4 w"]
+    [,"Compare Method using Ediff"     magik-ediff-methods     :active t :keys "f4 e"]
     "---"
-    [,"Add Debug Statement"         magik-add-debug-statement     :active t] ; FIXME former f4 s
+    [,"Add Debug Statement"         magik-add-debug-statement     :active t :keys "f4 s"]
     [,"Trace Statement"             magik-trace-curr-statement    :active t :keys "f2 t"]
-    [,"Symbol Complete"          magik-symbol-complete          :active (magik-utils-buffer-mode-list 'magik-session-mode)] ; FIXME former f4 f4
+    [,"Symbol Complete"  magik-symbol-complete :active (magik-utils-buffer-mode-list 'magik-session-mode) :keys "f4 f4"]
     ;; [,"Deep Print"        deep-print                     :active (and (fboundp 'deep-print)
     ;; 									      (magik-utils-buffer-mode-list 'magik-session-mode))
     ;;  :keys "f2 x"]
@@ -2194,15 +2194,15 @@ closing bracket into the new \"{...}\" notation."
   (define-key magik-mode-map (kbd "<f2> <down>") 'magik-forward-method)
   (define-key magik-mode-map (kbd "<f2> $")      'magik-transmit-$-chunk)
 
-  ;;  (define-key magik-f4-map [f4]   'magik-symbol-complete)
-  ;;  (define-key magik-f4-map "c"    'magik-copy-method)
-  ;;  (define-key magik-f4-map "e"    'magik-ediff-methods)
-  ;;  (define-key magik-f4-map [f3]   'magik-cb-magik-ediff-methods)
-  ;;  (define-key magik-f4-map "m"    'magik-copy-method-to-buffer)
-  ;;  (define-key magik-f4-map "n"    'magik-set-work-buffer-name)
-  ;;  (define-key magik-f4-map "r"    'magik-copy-region-to-buffer)
-  ;;  (define-key magik-f4-map "s"    'magik-add-debug-statement)
-  ;;  (define-key magik-f4-map "w"    'magik-compare-methods)
+  (define-key magik-mode-map (kbd "<f4> <f4>")   'magik-symbol-complete)
+  (define-key magik-mode-map (kbd "<f4> c")      'magik-copy-method)
+  (define-key magik-mode-map (kbd "<f4> e")      'magik-ediff-methods)
+  (define-key magik-mode-map (kbd "<f4> <f3>")   'magik-cb-magik-ediff-methods)
+  (define-key magik-mode-map (kbd "<f4> m")      'magik-copy-method-to-buffer)
+  (define-key magik-mode-map (kbd "<f4> n")    	 'magik-set-work-buffer-name)
+  (define-key magik-mode-map (kbd "<f4> r")    	 'magik-copy-region-to-buffer)
+  (define-key magik-mode-map (kbd "<f4> s")    	 'magik-add-debug-statement)
+  (define-key magik-mode-map (kbd "<f4> w")    	 'magik-compare-methods)
   )
 
 (eval-after-load 'flycheck

--- a/magik-mode.el
+++ b/magik-mode.el
@@ -2197,7 +2197,7 @@ closing bracket into the new \"{...}\" notation."
   ;;  (define-key magik-f4-map [f4]   'magik-symbol-complete)
   ;;  (define-key magik-f4-map "c"    'magik-copy-method)
   ;;  (define-key magik-f4-map "e"    'magik-ediff-methods)
-  ;;  (define-key magik-f4-map [f3]   'cb-magik-ediff-methods)
+  ;;  (define-key magik-f4-map [f3]   'magik-cb-magik-ediff-methods)
   ;;  (define-key magik-f4-map "m"    'magik-copy-method-to-buffer)
   ;;  (define-key magik-f4-map "n"    'magik-set-work-buffer-name)
   ;;  (define-key magik-f4-map "r"    'magik-copy-region-to-buffer)

--- a/magik-mode.el
+++ b/magik-mode.el
@@ -104,22 +104,22 @@ Users can also swap the point and mark positions using \\[exchange-point-and-mar
     [,"Transmit Thing"    magik-transmit-thing          :active (magik-utils-buffer-mode-list 'magik-session-mode)
      :keys "f2 RET"]
     "---"
-    [,"Copy Region to Work Buffer"  magik-copy-region-to-buffer   :active t :keys "f4 r"]
-    [,"Copy Method to Work Buffer"  magik-copy-method-to-buffer   :active t :keys "f4 m"]
-    [,"Set Work Buffer Name"   magik-set-work-buffer-name    :active t :keys "f4 n"]
+    [,"Copy Region to Work Buffer"  magik-copy-region-to-buffer   t] ; FIXME former f4 r
+    [,"Copy Method to Work Buffer"  magik-copy-method-to-buffer   t] ; FIXME former f4 m
+    [,"Set Work Buffer Name"        magik-set-work-buffer-name    t] ; FIXME former f4 n
     "---"
     [,"Electric Template" magik-explicit-electric-space :active t :keys "f2 SPC"]
     [,"Mark Method"       magik-mark-method             :active t :keys "C-M-h, f9"]
-    [,"Copy Method"       magik-copy-method             :active t :keys "f4 c, f6"]
-    [,"Compare Method between Windows"   magik-compare-methods         :active t :keys "f4 w"]
-    [,"Compare Method using Ediff"     magik-ediff-methods           :active t :keys "f4 e"]
+    [,"Copy Method"       magik-copy-method             :active t :keys "f6"] ; FIXME former f4 c, f6
+    [,"Compare Method between Windows"   magik-compare-methods         :active t] ; FIXME former f4 w
+    [,"Compare Method using Ediff"     magik-ediff-methods           :active t] ; FIXME former f4 e
     "---"
-    [,"Add Debug Statement"         magik-add-debug-statement     :active t :keys "f4 s"]
+    [,"Add Debug Statement"         magik-add-debug-statement     :active t] ; FIXME former f4 s
     [,"Trace Statement"             magik-trace-curr-statement    :active t :keys "f2 t"]
-    [,"Symbol Complete"          magik-symbol-complete          :active (magik-utils-buffer-mode-list 'magik-session-mode) :keys "f4 f4"]
-    [,"Deep Print"        deep-print                     :active (and (fboundp 'deep-print)
-								      (magik-utils-buffer-mode-list 'magik-session-mode))
-     :keys "f2 x"]
+    [,"Symbol Complete"          magik-symbol-complete          :active (magik-utils-buffer-mode-list 'magik-session-mode)] ; FIXME former f4 f4
+    ;; [,"Deep Print"        deep-print                     :active (and (fboundp 'deep-print)
+    ;; 									      (magik-utils-buffer-mode-list 'magik-session-mode))
+    ;;  :keys "f2 x"]
     "---"
     [,"Comment Region"           magik-comment-region          :active t :keys "f2 #"]
     [,"Uncomment Region"         magik-uncomment-region        :active t :keys "f2 ESC #"]

--- a/magik-module.el
+++ b/magik-module.el
@@ -59,7 +59,7 @@
 (define-key magik-module-f2-map   "d"     'magik-module-reload-module-definition)
 (define-key magik-module-f2-map   "s"     'magik-module-toggle-save-magikc)
 (define-key magik-module-f2-map   "r"     'magik-module-toggle-force-reload)
-(define-key magik-module-f2-map   "R"     'magik-module-toggle-remove-module)
+(define-key magik-module-f2-map   "R"     'magik-module-remove-module)
 
 (defvar magik-module-menu nil
   "Keymap for the Magik module.def buffer menu bar.")

--- a/magik-product.el
+++ b/magik-product.el
@@ -45,6 +45,7 @@
 (define-key magik-product-mode-map [f2]    'magik-product-f2-map)
 
 (define-key magik-product-f2-map    "b"    'magik-product-transmit-buffer)
+(define-key magik-product-f2-map    "r"    'magik-product-reinitialise)
 
 (defvar magik-product-menu nil
   "Keymap for the Magik product.def buffer menu bar")
@@ -55,7 +56,7 @@
     [,"Add product"                      magik-product-transmit-buffer
      :active (magik-utils-buffer-mode-list 'magik-session-mode)
      :keys "f2 b"]
-    [,"Reinitialise product"             product-reinitialise
+    [,"Reinitialise product"             magik-product-reinitialise
      :active (magik-utils-buffer-mode-list 'magik-session-mode)
      :keys "f2 r"]
     "---"

--- a/magik-session.el
+++ b/magik-session.el
@@ -111,23 +111,23 @@ setting of the Magik Prompt by calling `magik-session-prompt-get'."
 (setq magik-session-prompt "Magik\\(\\|SF\\)> ")
 
 (defcustom magik-session-command-history-max-length 90
-  "*The maximum length of the displayed `magik-session-command' in the SW -> GIS Command History submenu.
+  "*The maximum length of the displayed `magik-session-command' in the Magik Session -> Magik Session Command History submenu.
 `magik-session-command' is a string of the form \"[DIRECTORY] COMMAND ARGS\"."
   :group 'magik
   :type  'integer)
 
 (defcustom magik-session-command-history-max-length-dir (floor (/ magik-session-command-history-max-length 2))
-  "*The maximum length of the displayed directory path in the SW -> GIS Command History submenu."
+  "*The maximum length of the displayed directory path in the Magik Session -> Magik Session Command History submenu."
   :group 'magik
   :type  'integer)
 
 (defcustom magik-session-recall-cmd-move-to-end nil
   "*If t, move the cursor point to the end of the recalled command.
-This behaviour is available for \\[recall-prev-gis-cmd] and \\[recall-next-gis-cmd] only.
+This behaviour is available for \\[magik-session-recall-prev-cmd] and \\[magik-session-recall-next-cmd] only.
 The default is nil, which preserves the original behaviour to leave
 the cursor point in the same position.
 
-The similar commands, \\[recall-prev-matching-gis-cmd] and \\[recall-next-matching-gis-cmd]
+The similar commands, \\[magik-session-recall-prev-matching-cmd] and \\[magik-session-recall-next-matching-cmd]
 that use command string matching are not affected by this setting."
   :group 'magik
   :type 'boolean)
@@ -228,12 +228,12 @@ this variable buffer-local by putting the following in your .emacs
     [,"Previous Matching Command"        magik-session-recall-prev-matching-cmd  :active t :keys "f2 p"]
     [,"Next Matching Command"            magik-session-recall-next-matching-cmd  :active t :keys "f2 n"]
     "----"
-    [,"Fold"                             magik-session-display-history           :active t :keys "f2 up"]
-    [,"Unfold"                           magik-session-undisplay-history         :active t :keys "f2 down"]
+    [,"Fold"                             magik-session-display-history   :active t :keys "f2 up, f2 C-p"]
+    [,"Unfold"                           magik-session-undisplay-history :active t :keys "f2 down, f2 C-n"]
     "----"
-    [,"Electric Template"                magik-electric-explicit-space         :active t :keys "f2 SPC"]
+    [,"Electric Template"                magik-explicit-electric-space         :active t :keys "f2 SPC"]
     [,"Symbol Complete"                  magik-symbol-complete                 :active t :keys "f4 f4"]
-    [,"Deep Print"                       magik-deep-print                      :active t :keys "f2 x"]
+    ;; [,"Deep Print"                       magik-deep-print                      :active t :keys "f2 x"]
     "----"
     [,"Previous Traceback"               magik-session-traceback-up              :active t :keys "f4 up"]
     [,"Next Traceback"                   magik-session-traceback-down            :active t :keys "f4 down"]
@@ -242,11 +242,11 @@ this variable buffer-local by putting the following in your .emacs
     "----"
     [,"External Shell Process"           magik-session-shell                     :active t :keys "f4 $"]
     [,"Kill Magik Process"               magik-session-kill-process              :active (and magik-session-process
-											      (eq (process-status magik-session-process) 'run))]
-    (,"Magik Command History")
+										      (eq (process-status magik-session-process) 'run))]
+    (,"Magik Session Command History")
     "---"
     (,"Toggle..."
-     [,"Magik Session Filter"             magik-session-toggle-filter              :active t :keys "f2 f"
+     [,"Magik Session Filter"             magik-session-filter-toggle-filter     :active t :keys "f2 f"
       :style toggle :selected (let ((b (get-buffer-process
 					(current-buffer))))
 				(and b (process-filter b)))]
@@ -356,7 +356,7 @@ string for next time.")
   :type  'function)
 
 (defun magik-session-customize ()
-  "Open Customization buffer for Gis Mode."
+  "Open Customization buffer for Magik Session Mode."
   (interactive)
   (customize-group 'gis))
 
@@ -492,8 +492,8 @@ and return a list of all the components of the command."
 			    "..."))))
 	(concat label (substring command (+ command-len (length label)))))))
 
-(defun magik-session-update-sw-menu ()
-  "Update GIS process submenu in SW menu bar."
+(defun magik-session-update-tools-magik-gis-menu ()
+  "Update Magik Session processes submenu in Tools -> Magik pulldown menu."
   (let* ((magik-session-alist (sort (copy-alist magik-session-buffer-alist)
 				    #'(lambda (a b) (< (car a) (car b)))))
 	 magik-session-list)
@@ -513,8 +513,8 @@ and return a list of all the components of the command."
 		      "Magik Session Processes"
 		      (or magik-session-list (list "No Processes")))))
 
-(defun magik-session-update-gis-menu ()
-  "Update the GIS menu bar."
+(defun magik-session-update-magik-session-menu ()
+  "Update the Magik Session Command history in the Magik Session pulldown menu"
   (if (eq major-mode 'magik-session-mode)
       (let (command-list)
 	(save-match-data
@@ -552,8 +552,8 @@ and return a list of all the components of the command."
 			  "Magik Session Command History"
 			  (or command-list (list "No History"))))))
 
-(defun magik-session-update-sw-shell-menu ()
-  "Update GIS shell submenu in SW menu bar."
+(defun magik-session-update-tools-magik-shell-menu ()
+  "Update External Shell Processes submenu in Tools -> Magik pulldown menu."
   (let ((shell-bufs (magik-utils-buffer-mode-list 'shell-mode
 						  (function (lambda () (getenv "SMALLWORLD_GIS")))))
 	shell-list)
@@ -674,9 +674,9 @@ Entry to this mode calls the value of magik-session-mode-hook."
     (with-current-buffer (get-buffer-create (concat " *filter*" (buffer-name)))
       (erase-buffer))
 
-    (add-hook 'menu-bar-update-hook 'magik-session-update-gis-menu)
-    (add-hook 'menu-bar-update-hook 'magik-session-update-sw-menu)
-    (add-hook 'menu-bar-update-hook 'magik-session-update-sw-shell-menu)
+    (add-hook 'menu-bar-update-hook 'magik-session-update-magik-session-menu)
+    (add-hook 'menu-bar-update-hook 'magik-session-update-tools-magik-gis-menu)
+    (add-hook 'menu-bar-update-hook 'magik-session-update-tools-magik-shell-menu)
     (add-hook 'kill-buffer-hook 'magik-session-buffer-alist-remove nil t) ;local hook
     (run-hooks 'magik-session-mode-hook)))
 
@@ -1282,18 +1282,20 @@ An internal function that deals with 4 cases."
 	  ))))
 
 (defun magik-session-recall-prev-cmd ()
-  "Recall the earlier gis commands
-Cursor point is placed at end of command.
-Compare with \\[recall-prev-matching-gis-cmd] placing cursor
-immediately at the start of a command"
+  "Recall the earlier magik session commands 
+
+The variable \\[magik-session-recall-cmd-move-to-end\\] decides
+whether cursor point is placed at end of command.  Compare with
+\\[magik-session-recall-prev-matching-cmd]"
   (interactive "*")
   (magik-session-recall "" -1 magik-session-recall-cmd-move-to-end))
 
 (defun magik-session-recall-next-cmd ()
-  "Recall the later gis commands
-Cursor point is placed at end of command.
-Compare with \\[recall-next-matching-gis-cmd] placing cursor
-immediately at the start of a command"
+  "Recall the later magik session commands
+
+The variable \\[magik-session-recall-cmd-move-to-end\\] decides
+whether cursor point is placed at end of command.  Compare with
+\\[magik-session-recall-next-matching-cmd]"
   (interactive "*")
   (magik-session-recall "" 1 magik-session-recall-cmd-move-to-end))
 
@@ -1554,7 +1556,7 @@ the buffer to the printer.  Query first."
   (force-mode-line-update))
 
 (defun magik-session-drag-n-drop-load ()
-  "Load a drag and dropped file into the Gis session.
+  "Load a drag and dropped file into the Magik Session.
 If the previous buffer was a GIS session buffer and the previous event was
 a drag & drop event then we load the dropped file into the GIS session.
 
@@ -1635,16 +1637,16 @@ where MODE is the name of the major mode with the '-mode' postfix."
   (define-key magik-session-mode-map "\C-w"      'magik-session-kill-region)
   (define-key magik-session-mode-map [f8]        'magik-session-send-command-at-point)
   (define-key magik-session-mode-map "\C-c\C-c"  'magik-session-kill-process)
-  (define-key magik-session-mode-map "\C-c\C-\\" 'query-quit-shell-subjob)
-  (define-key magik-session-mode-map "\C-c\C-z"  'query-stop-shell-subjob)
-  (define-key magik-session-mode-map "\C-c\C-d"  'query-shell-send-eof)
+  (define-key magik-session-mode-map "\C-c\C-\\" 'magik-session-query-quit-shell-subjob)
+  (define-key magik-session-mode-map "\C-c\C-z"  'magik-session-query-stop-shell-subjob)
+  (define-key magik-session-mode-map "\C-c\C-d"  'magik-session-query-shell-send-eof)
 
-  (define-key magik-session-mode-map (kbd "<f2> <up>")   'display-gis-history)
-  (define-key magik-session-mode-map (kbd "<f2> \C-p")   'display-gis-history)
-  (define-key magik-session-mode-map (kbd "<f2> <down>") 'undisplay-gis-history)
-  (define-key magik-session-mode-map (kbd "<f2> \C-n")   'undisplay-gis-history)
+  (define-key magik-session-mode-map (kbd "<f2> <up>")   'magik-session-display-history)
+  (define-key magik-session-mode-map (kbd "<f2> \C-p")   'magik-session-display-history)
+  (define-key magik-session-mode-map (kbd "<f2> <down>") 'magik-session-undisplay-history)
+  (define-key magik-session-mode-map (kbd "<f2> \C-n")   'magik-session-undisplay-history)
   (define-key magik-session-mode-map (kbd "<f2> =")      'magik-session-traceback-print)
-  (define-key magik-session-mode-map (kbd "<f2> f")      'toggle-gis-filter)
+  (define-key magik-session-mode-map (kbd "<f2> f")      'magik-session-filter-toggle-filter)
   (define-key magik-session-mode-map (kbd "<f2> p")      'magik-session-recall-prev-matching-cmd)
   (define-key magik-session-mode-map (kbd "<f2> n")      'magik-session-recall-next-matching-cmd)
 
@@ -1656,7 +1658,7 @@ where MODE is the name of the major mode with the '-mode' postfix."
   (define-key magik-session-mode-map (kbd "<f4> m")      'magik-copy-method-to-buffer)
   (define-key magik-session-mode-map (kbd "<f4> r")      'magik-copy-region-to-buffer)
   (define-key magik-session-mode-map (kbd "<f4> s")      'magik-add-debug-statement)
-  (define-key magik-session-mode-map (kbd "<f4> w")      'magik-set-work-buffer)
+  (define-key magik-session-mode-map (kbd "<f4> w")      'magik-set-work-buffer-name)
   (define-key magik-session-mode-map (kbd "<f4> P")      'magik-session-traceback-print)
   (define-key magik-session-mode-map (kbd "<f4> S")      'magik-session-traceback-save))
 


### PR DESCRIPTION
With this Pull-Request several problems are fixed:
* correct missspelled callback functions of menu entries and key bindings
* removed non-functioning hints for short cuts in menu entries. 
* activated f4-key-combinations from former 'CST 430 emacs' in magik-mode
* comment out menu entries and key bindings, where no callback function is available. This gives the possibility for maintainers to add them later on, without the user beeing annoyed by a non functioning menu entry
* replace 'space' by 'SPC' as shortcut-hint in pulldown menus, which is the usually used naming for that key
* renaming a few functions for clarity as the menu names have been changed with respect to the former 'CST 430 emacs' and update their public comments:
  `magik-session-update-magik-session-menu` (has been `magik-session-update-gis-menu` before)
  `magik-session-update-tools-magik-gis-menu` (has been `magik-session-update-sw-menu` before)
  `magik-session-update-tools-magik-shell-menu` (has been `magik-session-update-sw-shell-menu` before)
  `magik-cb-update-tools-magik-cb-menu` (has been `magik-cb-update-sw-menu` before)
* correct some erroneous public function comments 
* README.md - some more clarifications, espcially about the overwritten standard EMACS-Keys <kbd>F2</kbd>,<kbd>F3</kbd>, and <kbd>F4</kbd>
