### PR TITLE
Support for Strings with single quote delimiters

### DIFF
--- a/magik-indent.el
+++ b/magik-indent.el
@@ -459,6 +459,7 @@ is an operator."
              "%" char
              "@" at
              "\"" string
+             "'" string1
              "_" keyword
              ":" sym
              "|" var-bar
@@ -509,6 +510,9 @@ is an operator."
     (string "\"" string-finish
             t stay)
     (string-finish t neutral)
+    (string1 "'" string1-finish
+             t stay)
+    (string1-finish t neutral)
     (comment t stay))
   "A description of the lexical state transitions in Magik.  This gets
 compiled into a more efficient form by `init-magik-state-table()'.")

--- a/magik-mode.el
+++ b/magik-mode.el
@@ -2112,7 +2112,8 @@ closing bracket into the new \"{...}\" notation."
   (modify-syntax-entry ?< "." magik-mode-syntax-table)
   (modify-syntax-entry ?> "." magik-mode-syntax-table)
   (modify-syntax-entry ?& "." magik-mode-syntax-table)
-  (modify-syntax-entry ?\" "\"" magik-mode-syntax-table))
+  (modify-syntax-entry ?\" "\"" magik-mode-syntax-table)
+  (modify-syntax-entry ?\' "\"" magik-mode-syntax-table))
 
 ;;; package setup via setting of variable before load.
 (and magik-method-name-mode


### PR DESCRIPTION
Besides strings with double quote delimiters like `"What's going on?"` Magik also allows strings to be delimited by single quotes like `'Tom said: "It is quite easy", but it is not.'`. With this pull request the magik-mode supports this, too.