### PR TITLE
Revert "Support for Strings with single quote delimiters"

### DIFF
--- a/magik-indent.el
+++ b/magik-indent.el
@@ -459,7 +459,6 @@ is an operator."
              "%" char
              "@" at
              "\"" string
-             "'" string1
              "_" keyword
              ":" sym
              "|" var-bar
@@ -510,9 +509,6 @@ is an operator."
     (string "\"" string-finish
             t stay)
     (string-finish t neutral)
-    (string1 "'" string1-finish
-             t stay)
-    (string1-finish t neutral)
     (comment t stay))
   "A description of the lexical state transitions in Magik.  This gets
 compiled into a more efficient form by `init-magik-state-table()'.")

--- a/magik-mode.el
+++ b/magik-mode.el
@@ -2112,8 +2112,7 @@ closing bracket into the new \"{...}\" notation."
   (modify-syntax-entry ?< "." magik-mode-syntax-table)
   (modify-syntax-entry ?> "." magik-mode-syntax-table)
   (modify-syntax-entry ?& "." magik-mode-syntax-table)
-  (modify-syntax-entry ?\" "\"" magik-mode-syntax-table)
-  (modify-syntax-entry ?\' "\"" magik-mode-syntax-table))
+  (modify-syntax-entry ?\" "\"" magik-mode-syntax-table))
 
 ;;; package setup via setting of variable before load.
 (and magik-method-name-mode


### PR DESCRIPTION
Reverts roadrunner1776/magik#22

Causes display problems with various strings, for example:
Magik> write("Doesn't understand")

Also, some display issues within the method finder/class browser