### PR TITLE
[magik-electric] Buffer name as filename isnt always safe

### DIFF
--- a/magik-electric.el
+++ b/magik-electric.el
@@ -283,7 +283,7 @@ the previous line starts with a `#' align with that."
 		(t nil)))
 	(if class (insert class "."))))
      ((eq line 'filename_as_symbol)
-      (let ((name (buffer-name)))
+      (let ((name (file-name-nondirectory (buffer-file-name))))
 	(if (string-match "\\.magik$" name)
 	    (setq name (substring name 0 (- (length name) 6))))
 	(insert ":" name)))


### PR DESCRIPTION
When you have the same filename opened from 2 different directories, the filename_as_symbol would become person.magik<directory_name>.

Example:
- person.magik in the directory develop
- person.magik in the directory master

Inserting def_slotted_exemplar for person.magik in develop would become:

`def_slotted_exemplar(:person.magik<develop>,`

Background info:
The `buffer-name` function returns the name of the buffer, not the name of the file which backs it; therefore it's not the true file name, since it can be filename<2> in the case of an indirect buffer, or *scratch*, which has no backing file at all. The function you want is `buffer-file-name`, which returns the full path (or nil); 
  
