### PR TITLE
[sw-method-docs] Add support for assignment method

### DIFF
--- a/magik-mode.el
+++ b/magik-mode.el
@@ -383,6 +383,8 @@ Based upon `font-lock-warning-face'"
 (defconst magik-regexp
   '(("method" .
      "^[_abstract\s|_private\s|_iter\s]*?_method.*(\\([\0-\377[:nonascii:]]*?\\))")
+    ("assignment-method" .
+     "^[_abstract\s|_private\s|_iter\s]*?_method.*<<\s?\\(.*\\)")
     ("endmethod" .
      "^\\s-*_endmethod\\s-*\\(\n\\$\\s-*\\)?$")
     ("method-argument" .
@@ -1853,6 +1855,9 @@ Argument END ..."
      ((eq major-mode 'magik-mode)
       (goto-char (point-min))
       (while (search-forward-regexp (cdr (assoc "method" magik-regexp)) nil t)
+        (magik-parse-sw-method-docs (match-string 1)))
+      (goto-char (point-min))
+      (while (search-forward-regexp (cdr (assoc "assignment-method" magik-regexp)) nil t)
         (magik-parse-sw-method-docs (match-string 1)))))))
 
 (defun magik-single-sw-method-docs ()
@@ -1864,8 +1869,12 @@ Argument END ..."
       (forward-line)
       (search-backward-regexp (cdr (assoc "method" magik-regexp)) nil t)
       (search-forward-regexp (cdr (assoc "method" magik-regexp)) nil t)
-      (unless (equal (match-string 1) nil)
-	(magik-parse-sw-method-docs (match-string 1)))))))
+      (if (not (equal (match-string 1) nil))
+	  (magik-parse-sw-method-docs (match-string 1))
+	(search-backward-regexp (cdr (assoc "assignment-method" magik-regexp)) nil t)
+	(search-forward-regexp (cdr (assoc "assignment-method" magik-regexp)) nil t)
+	(unless (equal (match-string 1) nil)
+	  (magik-parse-sw-method-docs (match-string 1))))))))
 
 (defun magik-parse-sw-method-docs (method-string)
   "Helper function for inserting sw-method-docs.


### PR DESCRIPTION
By adding this, we support adding sw-method-docs for assignment methods:

```
_method person.name << a_name
    _self.name << a_name
_endmethod
$
```