### PR TITLE
[magik-mode] Remove old F2-m references

### DIFF
--- a/magik-mode.el
+++ b/magik-mode.el
@@ -94,7 +94,7 @@ Users can also swap the point and mark positions using \\[exchange-point-and-mar
   "Menu for Magik Mode."
   `(,"Magik"
     [,"Transmit Method"   magik-transmit-method         :active (magik-utils-buffer-mode-list 'magik-session-mode)
-     :keys "f7, f2 f7, f2 m"]
+     :keys "f7, f2 f7"]
     [,"Transmit Region"   magik-transmit-region         :active (magik-utils-buffer-mode-list 'magik-session-mode)
      :keys "f8, f2 f8, f2 r"]
     [,"Transmit Buffer"   magik-transmit-buffer         :active (magik-utils-buffer-mode-list 'magik-session-mode)
@@ -1417,7 +1417,7 @@ Argument FILENAME ..."
   "Major mode for editing Magik code.
 
 Indents with the TAB or RET keys, inserts underscores, and sends Magik
-to a running gis with `F2 b', `F2 m', `F2 r', or `F2 RET'.
+to a running gis with `F2 b', `F2 r', or `F2 RET'.
 Creates programming templates like
   _if
   _then


### PR DESCRIPTION
Remove old F2-m references -> replaced by magik-single-sw-method-docs