### PR TITLE
avoid key binding conflict f2 m

### DIFF
--- a/magik-mode.el
+++ b/magik-mode.el
@@ -125,10 +125,10 @@ Users can also swap the point and mark positions using \\[exchange-point-and-mar
     [,"Uncomment Region"         magik-uncomment-region        :active t :keys "f2 ESC #"]
     [,"Fill Comment"              magik-fill-public-comment     :active t :keys "f2 q"]
     "---"
-    [,"Check sw-method-docs for method"  magik-single-sw-method-docs :active t :keys "f2 m"]
-    [,"Check sw-method-docs for file"  magik-file-sw-method-docs :active t :keys "f2 f"]
+    [,"Check sw-method-docs for method"  magik-single-sw-method-docs :active t :keys "f2 d"]
+    [,"Check sw-method-docs for file"  magik-file-sw-method-docs :active t :keys "f2 D"]
     [,"Check pragma for method/def_slotted_exemplar"  magik-single-pragma :active t :keys "f2 p"]
-    [,"Check pragma for file"  magik-file-pragma :active t :keys "f2 F"]
+    [,"Check pragma for file"  magik-file-pragma :active t :keys "f2 P"]
     "---"
     (,"Toggle.."
      [,"Method Name Display"      magik-method-name-mode
@@ -2352,9 +2352,9 @@ closing bracket into the new \"{...}\" notation."
   (define-key magik-mode-map (kbd "<f2> <up>")   'magik-backward-method)
   (define-key magik-mode-map (kbd "<f2> <down>") 'magik-forward-method)
   (define-key magik-mode-map (kbd "<f2> $")      'magik-transmit-$-chunk)
-  (define-key magik-mode-map (kbd "<f2> f")      'magik-file-sw-method-docs)
-  (define-key magik-mode-map (kbd "<f2> m")      'magik-single-sw-method-docs)
-  (define-key magik-mode-map (kbd "<f2> F")      'magik-file-pragma)
+  (define-key magik-mode-map (kbd "<f2> D")      'magik-file-sw-method-docs)
+  (define-key magik-mode-map (kbd "<f2> d")      'magik-single-sw-method-docs)
+  (define-key magik-mode-map (kbd "<f2> P")      'magik-file-pragma)
   (define-key magik-mode-map (kbd "<f2> p")      'magik-single-pragma)
 
   (define-key magik-mode-map (kbd "<f4> <f4>")   'magik-symbol-complete)


### PR DESCRIPTION
The key binding `<f2> m` for 'magik-single-sw-method-docs' hides the same key binding for 'magik-transmit-method' which is defined within magik-keys.el
As the 'magik-transmit-method' many people use very frequently using exactly this key binding, it seems to me to be important to avoid this conflict, although there might be are other workarounds.

With this pull request I change the key bindings for four functions in an easy to remember logical way:
* `<f2> d` 'magik-single-sw-method-docs'
* `<f2> D` 'magik-file-sw-method-docs'
* `<f2> p` 'magik-single-pragma' (unchanged)
* `<f2> P` 'magik-file-pragma' 

So now the 'single'-functions have a lowercase latter, whereas the 'file' functions have the corresponding uppercase latter.
d/D stands for method-**d**ocs
p/P stands for **p**ragma