### PR TITLE
Inititial tree-sitter-magik support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *~
 .*
 *.elc
+/magik-mode-autoloads.el
+/magik-mode-pkg.el

--- a/magik-aliases.el
+++ b/magik-aliases.el
@@ -526,8 +526,8 @@ Returns nil if FILE cannot be expanded."
 		     "Aliases Files (%d)")
 		    last))))
 
-(eval-after-load 'msb
-  '(magik-aliases-msb-configuration))
+(with-eval-after-load 'msb
+  (magik-aliases-msb-configuration))
 
 (provide 'magik-aliases)
 ;;; magik-aliases.el ends here

--- a/magik-cb.el
+++ b/magik-cb.el
@@ -85,7 +85,6 @@
 (require 'magik-mode)
 (require 'magik-session)
 (require 'magik-utils)
-(require 'cl-lib)
 (require 'easymenu)
 
 (defgroup magik-cb nil
@@ -655,7 +654,7 @@ To view the help on these variables type C-h v [Return] [variable-name]"
 
   (use-local-map magik-cb-mode-map)
   (easy-menu-add magik-cb-menu)
-  (set-syntax-table magik-mode-syntax-table)
+  (set-syntax-table magik-base-mode-syntax-table)
 
   (setq major-mode 'magik-cb-mode
 	buffer-read-only t
@@ -1551,7 +1550,7 @@ be careful to preserve the position in \"*cb2*\"."
 	font-lock-defaults '(magik-cb2-font-lock-keywords nil t ((?_ . "w"))))
 
   (use-local-map magik-cb-mode-map)
-  (set-syntax-table (copy-syntax-table magik-mode-syntax-table))
+  (set-syntax-table (copy-syntax-table magik-base-mode-syntax-table))
   (modify-syntax-entry ?\" "w")
   (modify-syntax-entry ?- "w")
 
@@ -2458,11 +2457,11 @@ See the variable `magik-cb-generalise-file-name-alist' to provide more customisa
 		     "CB (%d)")
 		    last))))
 
-(eval-after-load 'msb
-  '(magik-cb-msb-configuration))
+(with-eval-after-load 'msb
+  (magik-cb-msb-configuration))
 
-(eval-after-load 'autocomplete
-  '(require 'magik-cb-ac))
+(with-eval-after-load 'autocomplete
+  (require 'magik-cb-ac))
 
 (progn
   ;; ----------------------- cb mode ------------------------

--- a/magik-msg.el
+++ b/magik-msg.el
@@ -240,10 +240,9 @@ Called by `gis-drag-n-drop-load' when a Msg file is dropped."
     (push '("\\.hmsg$" . magik-msg-mode) auto-mode-alist))
 
 ;; speedbar configuration
-(eval-after-load 'speedbar
-  '(progn
-     (speedbar-add-supported-extension ".msg")
-     (speedbar-add-supported-extension ".hmsg")))
+(with-eval-after-load 'speedbar
+  (speedbar-add-supported-extension ".msg")
+  (speedbar-add-supported-extension ".hmsg"))
 
 ;;MSB configuration
 (defun magik-msg-msb-configuration ()
@@ -259,8 +258,8 @@ Called by `gis-drag-n-drop-load' when a Msg file is dropped."
 		     "Msg Files (%d)")
 		    last))))
 
-(eval-after-load 'msb
-  '(magik-msg-msb-configuration))
+(with-eval-after-load 'msb
+  (magik-msg-msb-configuration))
 
 (provide 'magik-msg)
 ;;; magik-msg.el ends here

--- a/magik-session.el
+++ b/magik-session.el
@@ -604,8 +604,7 @@ Entry to this mode calls the value of magik-session-mode-hook."
     (make-local-variable 'ac-sources)
 
     (use-local-map magik-session-mode-map)
-    (easy-menu-add magik-session-menu)
-    (set-syntax-table magik-mode-syntax-table)
+    (set-syntax-table magik-base-mode-syntax-table)
 
     (if (null tmp-no-of-gis-cmds)
 	(progn
@@ -622,7 +621,7 @@ Entry to this mode calls the value of magik-session-mode-hook."
     (setq major-mode 'magik-session-mode
 	  mode-name "Magik Session"
 	  selective-display t
-	  local-abbrev-table magik-mode-abbrev-table
+	  local-abbrev-table magik-base-mode-abbrev-table
 	  comint-last-input-start (make-marker)
 	  comint-last-input-end   (make-marker)
 	  magik-session-command-history (or magik-session-command-history (default-value 'magik-session-command-history))
@@ -1609,11 +1608,11 @@ where MODE is the name of the major mode with the '-mode' postfix."
 		     "GIS (%d)")
 		    last))))
 
-(eval-after-load 'msb
-  '(magik-session-msb-configuration))
+(with-eval-after-load 'msb
+  (magik-session-msb-configuration))
 
-(eval-after-load 'auto-complete
-  '(add-to-list 'ac-modes 'magik-session-mode))
+(with-eval-after-load 'auto-complete
+  (add-to-list 'ac-modes 'magik-session-mode))
 
 (progn
   ;; ---------------------- magik session mode -------------------------

--- a/magik-treesit.el
+++ b/magik-treesit.el
@@ -1,0 +1,119 @@
+;;; magik-treesit.el ---                             -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2023  Robin Putters
+
+;; Author: Robin Putters <krn-robin@github>
+;; Keywords: languages
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;
+
+;;; Code:
+
+(require 'magik-mode)
+(require 'treesit)
+
+(defvar magik--treesit-settings
+  (treesit-font-lock-rules
+   :language 'magik
+   :feature 'pragma
+   '((pragma) @magik-pragma-face)
+
+   :language 'magik
+   :feature 'comment
+   '((comment) @font-lock-comment-face
+     (documentation) @magik-doc-face)
+
+   :language 'magik
+   :feature 'type
+   '((method
+      exemplarname: (identifier) @font-lock-type-face
+      name: (identifier) @magik-method-face)
+     (call
+      message: (identifier) @magik-method-face)
+     (slot_accessor) @magik-slot-face
+     (iterator (identifier) @font-lock-variable-name-face)
+     [(variable) (dynamic_variable) (global_variable)] @font-lock-variable-name-face)
+
+   :language 'magik
+   :feature 'error
+   '((ERROR) @font-lock-warning-face)
+
+   :language 'magik
+   :override t
+   :feature 'string
+   '((string_literal) @font-lock-string-face)
+
+   :language 'magik
+   :feature 'constant
+   '([(number) (character_literal)] @font-lock-constant-face
+     [(symbol)] @magik-symbol-face)
+
+   :language 'magik
+   :feature 'keyword
+   `([(false) (true) (maybe) (unset)] @font-lock-constant-face ;;FIXME "_constant"
+
+     ["_and" "_andif" "_div" "_is" "_isnt" "_cf" "_mod" "_not" "_or" "_orif" "_xor" "_xorif"] @magik-keyword-operators-face
+
+     [(self) (super)] @font-lock-type-face ;;FIXME "_clone"
+
+     ["_abstract" "_private"  "_method" "_endmethod"] @magik-method-face ;;FIXME "_primitive"
+
+     ["_proc" "_endproc"] @magik-procedure-face
+
+     ["_block" "_endblock" "_catch" "_throw" "_endcatch"
+      "_if" "_then" "_elif" "_else" "_endif"
+      "_protect" "_locking" "_protection" "_endprotect" ;;FIXME "_lock" "_endlock"
+      "_try" "_endtry" "_when" "_handling" "_with"  ;;FIXME  "_using"
+       "_package" "_default"] @magik-keyword-statements-face ;;FIXME "_pragma" "_thisthread"
+
+      ["_iter" "_continue" "_for" "_loop" "_endloop" "_loopbody" "_over" "_leave"] @magik-keyword-loop-face ;;FIXME: "_finally"  "_while"
+
+      ["_gather" "_scatter" "_optional" "_return" ">>"] @magik-keywords-arguments-face ;;FIXME "_allresults"
+
+      ["_dynamic" "_global" "_import" "_local" ] @magik-keyword-variable-face))) ;;FIXME "_class" "_recursive"
+
+;;;###autoload
+(define-derived-mode magik-ts-mode magik-base-mode "Magik"
+  "Major mode for editing Magik code, using tree-sitter library."
+  :group 'magik
+  :abbrev-table nil
+  :syntax-table nil
+
+  ;; Tree-sitter setup.
+  (treesit-parser-create 'magik)
+
+  (setq-local treesit-font-lock-settings magik--treesit-settings
+	      treesit-font-lock-feature-list '((comment pragma)
+					       (type constant keyword string)
+					       ()
+					       ()
+					       (error)))
+  (treesit-major-mode-setup))
+
+(with-eval-after-load 'treesit-auto
+  (add-to-list 'treesit-auto-recipe-list
+		(make-treesit-auto-recipe
+		 :lang 'magik
+		 :ts-mode 'magik-ts-mode
+		 :remap 'magik-mode
+		 :url "https://github.com/krn-robin/tree-sitter-magik"
+		 :revision "main"
+		 :source-dir "src")))
+
+(provide 'magik-treesit)
+;;; magik-treesit.el ends here

--- a/magik-utils.el
+++ b/magik-utils.el
@@ -21,6 +21,7 @@
 
 (eval-when-compile
   (require 'sort))
+(require 'cl-lib)
 
 (defvar magik-utils-original-process-environment (cl-copy-list process-environment)
   "Store the original `process-environment' at startup.


### PR DESCRIPTION
Work in progress. Only tested on Emacs 29+ ; probably needs some work to get the original magik-mode working again on Emacsen without tree-sitter support (Emacs 28 and older).