### PR TITLE
[loadlist] Ignore resources

### DIFF
--- a/magik-loadlist.el
+++ b/magik-loadlist.el
@@ -30,7 +30,7 @@
   :group 'magik-loadlist
   :type  'hook)
 
-(defcustom magik-loadlist-ignore-regexp-list '("\\..*")
+(defcustom magik-loadlist-ignore-regexp-list '("\\..*" "resources")
   "List of Regexps used to miss certain files from load_list.txt files.
 Intial ^ and final $ is automatically added in `loadlist-ignore'."
   :group 'magik-loadlist


### PR DESCRIPTION
resources should be ignored since those folders shouldn't contain any magik-files that have to be loaded when loading the load_list.txt