### PR TITLE
magik-treesit: update indent rules

### DIFF
--- a/magik-treesit.el
+++ b/magik-treesit.el
@@ -118,6 +118,7 @@
      ((node-is "elif") parent 0)
      ((node-is "else") parent 0)
      ((node-is "when") parent 0)
+     ((node-is "finally") parent 0)
 
      ((parent-is "block") parent magik-indent-level)
      ((parent-is "if") parent magik-indent-level)
@@ -125,7 +126,6 @@
      ((parent-is "else") parent magik-indent-level)
      ((parent-is "iterator") parent magik-indent-level)
      ((parent-is "loop") parent magik-indent-level)
-     ((parent-is "finally") parent magik-indent-level)
      ((parent-is "while") parent magik-indent-level)
      ((parent-is "method") parent magik-indent-level)
      ((parent-is "protect") parent magik-indent-level)

--- a/magik-treesit.el
+++ b/magik-treesit.el
@@ -134,12 +134,12 @@
      ((parent-is "try") parent magik-indent-level)
      ((parent-is "catch") parent magik-indent-level)
      ((parent-is "handling") parent magik-indent-level)
-
      ((parent-is "assignment") parent magik-indent-level)
-     ((parent-is "logical_operator") parent magik-indent-level)
-     ((parent-is "relational_operator") parent magik-indent-level)
-     ((parent-is "arithmetic_operator") parent magik-indent-level)
-     ((parent-is "unary_operator") parent magik-indent-level)
+
+     ((parent-is "logical_operator") parent 0)
+     ((parent-is "relational_operator") parent 0)
+     ((parent-is "arithmetic_operator") parent 0)
+     ((parent-is "unary_operator") parent 0)
 
      ((parent-is "documentation") first-sibling 0)
      ((parent-is "invoke") (nth-sibling 2) 0)


### PR DESCRIPTION
- Use `0` for all operators to indent the next snippet to:

```
_block
	a _and
	b
_endblock
$
```

instead of:
```
_block
	a _and
		b
_endblock
$
```

- Fix indent rule for `_finally` to indent the next snippet to:

```
_loop
    <do_something>
_finally
    <do_something>
_endloop
```

instead of:
```
_loop
    <do_something>
    _finally
    <do_something>
_endloop
```