### PR TITLE
[magik-treesit] Add font-lock-rule for indexing method and use more magik-faces

### DIFF
--- a/magik-mode.el
+++ b/magik-mode.el
@@ -259,9 +259,38 @@ concrete implementations."
   "Fontification colours for Magik."
   :group 'magik)
 
+;; font-lock-variable-use-face was introduced in Emacs 29.1.
+(unless (member `font-lock-variable-use-face (face-list))
+  (put 'font-lock-variable-use 'face-alias 'font-lock-variable-name-face))
+
+(defface magik-argument-face
+  '((t (:inherit font-lock-variable-use-face)))
+  "Font-lock Face to use when displaying arguments for methods."
+  :group 'magik-faces)
+
+(defface magik-boolean-face
+  '((t (:inherit font-lock-variable-name-face)))
+  "Font-lock Face to use when displaying boolean and kleenean references."
+  :group 'magik-faces)
+
+(defface magik-character-face
+  '((t (:inherit font-lock-constant-face)))
+  "Font-lock Face to use when displaying characters."
+  :group 'magik-faces)
+
 (defface magik-class-face
   '((t (:inherit font-lock-type-face)))
   "Font-lock Face to use when displaying exemplars."
+  :group 'magik-faces)
+
+(defface magik-comment-face
+  '((t (:inherit font-lock-comment-face)))
+  "Font-lock Face to use when displaying comments."
+  :group 'magik-faces)
+
+(defface magik-constant-face
+  '((t (:inherit font-lock-constant-face)))
+  "Font-lock Face to use when displaying constants."
   :group 'magik-faces)
 
 (defface magik-doc-face
@@ -281,7 +310,7 @@ concrete implementations."
 
 (defface magik-keyword-loop-face
   '((t (:inherit font-lock-keyword-face)))
-  "Font-lock Face to use when displaying Magik statement keywords."
+  "Font-lock Face to use when displaying Magik loop keywords."
   :group 'magik-faces)
 
 (defface magik-keyword-arguments-face
@@ -291,7 +320,17 @@ concrete implementations."
 
 (defface magik-dynamic-face
   '((t (:inherit font-lock-variable-name-face)))
-  "Face to use when displaying dynamic variables."
+  "Font-lock Face to use when displaying dynamic variables."
+  :group 'magik-faces)
+
+(defface magik-global-face
+  '((t (:inherit font-lock-variable-name-face)))
+  "Font-lock Face to use when displaying global variables."
+  :group 'magik-faces)
+
+(defface magik-global-reference-face
+  '((t (:inherit font-lock-constant-face)))
+  "Font-lock Face to use when displaying global references."
   :group 'magik-faces)
 
 (defface magik-keyword-variable-face
@@ -304,14 +343,23 @@ concrete implementations."
   "Font-lock Face to use when displaying obsolete Magik keywords."
   :group 'magik-faces)
 
-(defface magik-boolean-face
-  '((t (:inherit font-lock-variable-name-face)))
-  "Font-lock Face to use when displaying boolean and kleenean references."
-  :group 'magik-faces)
-
 (defface magik-method-face
   '((t (:inherit font-lock-function-name-face)))
   "Font-lock Face to use when displaying method names and method and procedure keywords."
+  :group 'magik-faces)
+
+(defface magik-label-face
+  '((t (:inherit font-lock-variable-name-face)))
+  "Font-lock Face to use when displaying labels for loops."
+  :group 'magik-faces)
+
+;; font-lock-number-face was introduced in Emacs 29.1 as new face without any inheritance.
+(unless (member `font-lock-number-face (face-list))
+  (put 'font-lock-number-face 'face-alias 'font-lock-constant-face))
+
+(defface magik-number-face
+  '((t (:inherit font-lock-number-face)))
+  "Font-lock Face to use when displaying numbers."
   :group 'magik-faces)
 
 (defface magik-pragma-face
@@ -332,6 +380,16 @@ concrete implementations."
 (defface magik-symbol-face
   '((t (:inherit font-lock-constant-face)))
   "Font-lock Face to use when displaying symbols."
+  :group 'magik-faces)
+
+(defface magik-string-face
+  '((t (:inherit font-lock-string-face)))
+  "Font-lock Face to use when displaying strings."
+  :group 'magik-faces)
+
+(defface magik-variable-face
+  '((t (:inherit font-lock-variable-name-face)))
+  "Font-lock Face to use when displaying variables."
   :group 'magik-faces)
 
 (defface magik-warning-face
@@ -362,8 +420,12 @@ concrete implementations."
     )
   "List of regexp strings which can be used for searching for a magik-specific string in a buffer.")
 
+(defvar magik-keyword-kleenean
+  '("false" "true" "maybe")
+  "List of keywords relating to kleenean values to highlight for font-lock.")
+
 (defvar magik-keyword-constants
-  '("false" "true" "maybe" "unset" "constant")
+  '("unset" "constant")
   "List of keywords relating to constant values to highlight for font-lock.
 The \"no_way\" constant is treated as a special case in this Magik mode
 because it does not have an _ preceding like all the other Magik keywords.")
@@ -393,7 +455,7 @@ because it does not have an _ preceding like all the other Magik keywords.")
   "List of keywords relating to statements to highlight for font-lock.")
 
 (defvar magik-keyword-loop
-  '("iter" "continue" "finally" "for" "loop" "endloop" "loopbody" "over" "leave" "while")
+  '("iter" "continue" "for" "loop" "endloop" "loopbody" "over" "leave" "finally" "while")
   "List of keywords relating to loops to highlight for font-lock.")
 
 (defvar magik-keyword-arguments
@@ -401,7 +463,7 @@ because it does not have an _ preceding like all the other Magik keywords.")
   "List of keywords relating to arguments to highlight for font-lock.")
 
 (defvar magik-keyword-variable
-  '("class" "dynamic" "global" "import" "local" "recursive")
+  '("dynamic" "global" "import" "local" "class" "recursive")
   "List of keywords relating to variables to highlight for font-lock.")
 
 (defvar magik-keyword-obsolete
@@ -417,7 +479,7 @@ because it does not have an _ preceding like all the other Magik keywords.")
 
 (defcustom magik-font-lock-keywords-1
   (list
-   (cons (concat "\\<no_way\\|_" (regexp-opt magik-keyword-constants t) "\\>") 'font-lock-constant-face)
+   (cons (concat "\\<no_way\\|_" (regexp-opt magik-keyword-constants t) "\\>") 'magik-constant-face)
    (cons (concat "\\<_"
 		 (regexp-opt (append magik-keyword-operators
 				     magik-keyword-class
@@ -469,8 +531,9 @@ See `magik-font-lock-keywords-1' and `magik-font-lock-keywords-2'."
   (append
    magik-font-lock-keywords-2
    (list
-    (cons (concat "\\<no_way\\|_" (regexp-opt magik-keyword-constants t) "\\>") ''font-lock-constant-face)
-    (cons (concat "\\<_" (regexp-opt magik-keyword-constants  t) "\\>") ''font-lock-constant-face)
+    (cons (concat "\\<_" (regexp-opt magik-keyword-kleenean  t) "\\>") ''magik-boolean-face)
+    (cons (concat "\\<no_way\\|_" (regexp-opt magik-keyword-constants t) "\\>") ''magik-constant-face)
+    (cons (concat "\\<_" (regexp-opt magik-keyword-constants  t) "\\>") ''magik-constant-face)
     (cons (concat "\\<_" (regexp-opt magik-keyword-operators  t) "\\>") ''magik-keyword-operators-face)
     (cons (concat "\\<_" (regexp-opt magik-keyword-class      t) "\\>") ''magik-class-face)
     (cons (concat "\\<_" (regexp-opt magik-keyword-methods    t) "\\>") ''magik-method-face)
@@ -493,8 +556,8 @@ See `magik-font-lock-keywords-1' and `magik-font-lock-keywords-2'."
     '("^\\(\\sw+\\)\\.define_\\(shared_constant\\|shared_variable\\|slot_access\\)\\>" 1 'magik-class-face)
     '("\\Sw\\(\\.\\sw*\\(\\s$\\S$*\\s$\\sw*\\)?\\)\\>" 1 'magik-slot-face)
     '("\\<\\sw*\\(\\s$\\S$*\\s$\\sw*\\)?\\?\\>" 0 'magik-boolean-face t)
-    '("_for\\s-+\\(\\sw+\\)" 1 'font-lock-variable-name-face) ;_for loop variable
-    '("@\\s-*\\sw+" 0 'font-lock-constant-face t)
+    '("_for\\s-+\\(\\sw+\\)" 1 'magik-variable-face) ;_for loop variable
+    '("@\\s-*\\sw+" 0 'magik-global-reference-face t)
     ))
   "Font lock setting for 4th level of Magik fontification.
 As 1st level but also fontifies all Magik keywords according their

--- a/magik-treesit.el
+++ b/magik-treesit.el
@@ -43,6 +43,9 @@
    '((method
       exemplarname: (identifier) @font-lock-type-face
       name: (identifier) @magik-method-face)
+     (method
+      exemplarname: (identifier) @magik-class-face
+      (argument) @magik-argument-face)
      (call
       message: (identifier) @magik-method-face)
      (slot_accessor) @magik-slot-face

--- a/magik-treesit.el
+++ b/magik-treesit.el
@@ -35,46 +35,52 @@
 
    :language 'magik
    :feature 'comment
-   '((comment) @font-lock-comment-face
+   '((comment) @magik-comment-face
      (documentation) @magik-doc-face)
 
    :language 'magik
    :feature 'type
    '((method
-      exemplarname: (identifier) @font-lock-type-face
+      exemplarname: (identifier) @magik-class-face
       name: (identifier) @magik-method-face)
      (method
       exemplarname: (identifier) @magik-class-face
       (argument) @magik-argument-face)
      (call
       message: (identifier) @magik-method-face)
+     (iterator (identifier) @magik-variable-face)
+     (try
+      condition: (identifier) @magik-variable-face)
      (slot_accessor) @magik-slot-face
-     (try (identifier) @font-lock-variable-name-face)
-     (label) @font-lock-variable-name-face
-     [(variable) (dynamic_variable) (global_variable)] @font-lock-variable-name-face)
+     (label) @magik-label-face
+     (variable) @magik-variable-face
+     (global_variable) @magik-global-face
+     (dynamic_variable) @magik-dynamic-face
+     (global_reference) @magik-global-reference-face)
 
    :language 'magik
    :feature 'error
-   '((ERROR) @font-lock-warning-face)
+   '((ERROR) @magik-warning-face)
 
    :language 'magik
    :override t
    :feature 'string
-   '((string_literal) @font-lock-string-face)
+   '((string_literal) @magik-string-face)
 
    :language 'magik
    :feature 'constant
-   '([(number) (character_literal)] @font-lock-constant-face
-     [(symbol)] @magik-symbol-face)
+   '((number) @magik-number-face
+     (character_literal) @magik-character-face
+     (symbol) @magik-symbol-face)
 
    :language 'magik
    :feature 'keyword
-   `([(false) (true) (maybe) (unset)] @font-lock-constant-face
-     ["_constant"] @font-lock-constant-face
+   `([(false) (true) (maybe)] @magik-boolean-face
+     [(unset) "_constant"] @magik-constant-face
 
      ["_and" "_andif" "_div" "_is" "_isnt" "_cf" "_mod" "_not" "_or" "_orif" "_xor" "_xorif"] @magik-keyword-operators-face
 
-     [(self) (super) (clone)] @font-lock-type-face
+     [(self) (super) (clone)] @magik-class-face
 
      ["_abstract" "_private"  "_method" "_endmethod" "_primitive"] @magik-method-face
 


### PR DESCRIPTION
Depends on the next version of [tree-sitter-magik](https://github.com/krn-robin/tree-sitter-magik).

This will font-lock all parameters inside the `[` and `]` correctly. The upper buffer is the `magik-mode` and the lower buffer is the `magik-ts-mode`.

<img width="290" alt="image" src="https://github.com/roadrunner1776/magik/assets/12570668/5ef9927b-e9ea-4948-be55-170db370a3b1">
