### PR TITLE
[magik-mode.el] Add kleenean to `magik-font-lock-keywords-1`

### DIFF
--- a/magik-mode.el
+++ b/magik-mode.el
@@ -487,6 +487,7 @@ because it does not have an _ preceding like all the other Magik keywords.")
 
 (defcustom magik-font-lock-keywords-1
   (list
+   (cons (concat "\\<_" (regexp-opt magik-keyword-kleenean  t) "\\>") ''magik-boolean-face)
    (cons (concat "\\<no_way\\|_" (regexp-opt magik-keyword-constants t) "\\>") 'magik-constant-face)
    (cons (concat "\\<_"
 		 (regexp-opt (append magik-keyword-operators


### PR DESCRIPTION
`magik-font-lock-keywords-1` is used in `magik-session`. By moving `false`, `true` and `maybe` from `magik-keyword-constants` to it's own group `magik-keyword-kleenean`, we need to add this new group to the same constructions as `magik-keyword-constants`.