### PR TITLE
Bump the magik linter to 0.9.1

### DIFF
--- a/magik-lint.el
+++ b/magik-lint.el
@@ -32,7 +32,7 @@
 	(cdr (assoc 'tag_name response))))))
 
 (defcustom magik-lint-jar-file-version
-  (or (magik-lint--latest-version) "0.8.3")
+  (or (magik-lint--latest-version) "0.9.1")
   "Version of magik-lint to use."
   :group 'magik
   :type 'string)


### PR DESCRIPTION
Release: https://github.com/StevenLooman/magik-tools/releases/tag/0.9.1
Change log: https://github.com/StevenLooman/magik-tools/blob/f46c7870ddb8c5c7eaed03e2d8684c8bdbdde4ed/CHANGES.md?plain=1#L11

CC: @StevenLooman