### PR TITLE
Mode-maps added to the doc strings of the mode functions.

### DIFF
--- a/magik-aliases.el
+++ b/magik-aliases.el
@@ -153,7 +153,9 @@ If any function returns t, then the buffer is displayed."
 (defun magik-aliases-mode ()
   "Major mode for editing Magik aliases files.
 
-You can customise magik-aliases-mode with the magik-aliases-mode-hook."
+You can customise magik-aliases-mode with the magik-aliases-mode-hook.
+
+\\{magik-aliases-mode-map}"
 
   (interactive)
   (kill-all-local-variables)

--- a/magik-cb.el
+++ b/magik-cb.el
@@ -634,7 +634,9 @@ Useful configuration variables are:
 
 cb-jump-replaces-cb-buffer
 
-To view the help on these variables type C-h v [Return] [variable-name]"
+To view the help on these variables type C-h v [Return] [variable-name]
+
+\\{magik-cb-mode-map}"
   (interactive)
   (kill-all-local-variables)
   (make-local-variable 'magik-cb-process)

--- a/magik-loadlist.el
+++ b/magik-loadlist.el
@@ -76,7 +76,9 @@ Intial ^ and final $ is automatically added in `loadlist-ignore'."
 (defun magik-loadlist-mode ()
   "Major mode for editing Magik load_list.txt files.
 
-You can customise magik-loadlist-mode with the magik-loadlist-mode-hook."
+You can customise magik-loadlist-mode with the magik-loadlist-mode-hook.
+
+\\{magik-loadlist-mode-map}"
 
   (interactive)
   (kill-all-local-variables)

--- a/magik-module.el
+++ b/magik-module.el
@@ -142,7 +142,9 @@
 (defun magik-module-mode ()
   "Major mode for editing Magik module.def files.
 
-You can customise Module Mode with the `module-mode-hook'."
+You can customise Module Mode with the `module-mode-hook'.
+
+\\{magik-module-mode-map}"
 
   (interactive)
   (kill-all-local-variables)

--- a/magik-msg.el
+++ b/magik-msg.el
@@ -138,7 +138,9 @@
 (defun magik-msg-mode ()
   "Major mode for editing Magik Message files.
 
-You can customise msg-mode with the msg-mode-hook."
+You can customise msg-mode with the msg-mode-hook.
+
+\\{magik-msg-mode-map}"
 
   (interactive)
   (kill-all-local-variables)

--- a/magik-pragma.el
+++ b/magik-pragma.el
@@ -459,7 +459,9 @@ q      - quit
            (forward-line)))))))
 
 (defun magik-pragma-topic-select-mode ()
-  "Major mode for selecting topics in pragmas"
+  "Major mode for selecting topics in pragmas.
+
+\\{magik-pragma-topic-select-mode-map}"
   (interactive)
   (kill-all-local-variables)
   (setq major-mode 'topic-select-mode)

--- a/magik-product.el
+++ b/magik-product.el
@@ -94,7 +94,9 @@
 (defun magik-product-mode ()
   "Major mode for editing Magik product.def files.
 
-You can customise Product Mode with the `product-mode-hook'."
+You can customise Product Mode with the `product-mode-hook'.
+
+\\{magik-product-mode-map}"
 
   (interactive)
   (kill-all-local-variables)

--- a/magik-session.el
+++ b/magik-session.el
@@ -575,7 +575,9 @@ help on F1).
 
 Commands are sent to the gis with the F8 key or the return key.
 
-Entry to this mode calls the value of magik-session-mode-hook."
+Entry to this mode calls the value of magik-session-mode-hook.
+
+\\{magik-session-mode-map}"
 
   (interactive)
   (let

--- a/magik-version.el
+++ b/magik-version.el
@@ -210,7 +210,9 @@ has more than one aliases file available."
 
 ;;;###autoload
 (defun magik-version-mode ()
-  "Major Mode for gis_version."
+  "Major Mode for gis_version.
+
+\\{magik-version-mode-map}"
   (interactive)
   (kill-all-local-variables)
   (make-local-variable 'magik-version-position)


### PR DESCRIPTION
Added mode-maps to the docstrings. 
This way the keybindings of the maps are easily discoverable through `describe-mode` (C-h m).