### PR TITLE
Prompt for gis buffers when customization is set

### DIFF
--- a/magik-utils.el
+++ b/magik-utils.el
@@ -22,6 +22,16 @@
 (eval-when-compile
   (require 'sort))
 (require 'cl-lib)
+(require 'seq)
+
+(defcustom magik-utils-by-default-prompt-buffer-p nil
+  "Defines if prompting for an gis buffer is used by default.
+This relates to the function `magik-utils-get-buffer-mode'.
+Any non-nil value means that the user will be prompted with
+the possible gis buffer options.  A value of nil makes it
+use the DEFAULT value that had been passed in."
+  :type 'boolean
+  :group 'magik)
 
 (defvar magik-utils-original-process-environment (cl-copy-list process-environment)
   "Store the original `process-environment' at startup.
@@ -234,7 +244,7 @@ Used for determining a suitable BUFFER using the following interface:
 5. Use the buffer displayed in the some other frame,
    only PROMPT if more than one buffer in the other frames are displayed
    and only list those that are displayed in the other frames.
-6. Use DEFAULT value.
+6. Use DEFAULT value, or PROMPT if `magik-utils-by-default-prompt-buffer-p' is not nil.
 "
   (let* ((prefix-fn (or prefix-fn
 			#'(lambda (arg mode predicate)
@@ -242,40 +252,29 @@ Used for determining a suitable BUFFER using the following interface:
 				 (reverse (magik-utils-buffer-mode-list-sorted mode predicate))))))
 	 (prompt (concat prompt " "))
 	 (visible-bufs (magik-utils-buffer-visible-list mode predicate))
-	 bufs
-	 (buffer (cond ((and (integerp current-prefix-arg)
-			     (setq buffer (funcall prefix-fn current-prefix-arg mode predicate)))
-			buffer)
-		       (current-prefix-arg
-			(completing-read prompt
-					 (mapcar #'(lambda (b) (cons b b))
-						 (magik-utils-buffer-mode-list mode predicate))
-					 nil nil
-					 initial))
-		       (buffer buffer)
-		       ((and
-			 (setq bufs
-			       (delete nil
-				       (mapcar (function (lambda (b) (if (cdr b) b))) visible-bufs)))
-			 ;;restrict list to those whose cdr is t.
-			 (setq buffer
-			       (if (= (length bufs) 1)
-				   (caar bufs)
-				 (completing-read prompt visible-bufs 'cdr t)))
-			 (not (equal buffer "")))
-			buffer)
-		       ((and
-			 visible-bufs
-			 (setq buffer
-			       (if (= (length visible-bufs) 1)
-				   (caar visible-bufs)
-				 (completing-read prompt visible-bufs nil t)))
-			 (not (equal buffer "")))
-			(select-frame-set-input-focus
-			 (window-frame (get-buffer-window buffer 'visible)))
-			buffer)
-		       (t default))))
-    buffer))
+	 (prompt-when-multiple-options
+	  #'(lambda (buffers predicate)
+	      (and buffers
+	       (setq buffer
+		     (if (length= buffers 1) (caar buffers)
+		       (completing-read prompt buffers predicate t)))
+	       (not (equal buffer "")))))
+	 (prompt-always #'(lambda ()
+			    (completing-read prompt
+					     (mapcar #'(lambda (b) (cons b b))
+						     (magik-utils-buffer-mode-list mode predicate))
+					     nil nil
+					     initial))))
+    (cond ((integerp current-prefix-arg) (funcall prefix-fn current-prefix-arg mode predicate))
+	  (current-prefix-arg (funcall prompt-always))
+	  (buffer buffer)
+	  ((funcall prompt-when-multiple-options (seq-filter #'(lambda (buff) (cdr buff)) visible-bufs) 'cdr)
+	   buffer)
+	  ((funcall prompt-when-multiple-options visible-bufs nil)
+	   (select-frame-set-input-focus
+	    (window-frame (get-buffer-window buffer 'visible))))
+	  (magik-utils-by-default-prompt-buffer-p (funcall prompt-always))
+	  (t default))))
 
 (defun magik-utils-delete-process-safely (process)
   "A safe `delete-process'.


### PR DESCRIPTION
Prompt by default for magik-utils-get-buffer-mode when magik-utils-by-default-prompt-buffer-p is set.

This allows for a workflow to prompt by default for gis or class-browser buffers when they are not visible or there are multiple sessions running.
Without the need for a prefix-argument.

Also when multiple gis sessions are running, or multiple gis sessions/buffers have been made over the course of the emacs session. Then the DEFAULT value is wrong most of the time. And because of that the interactive command which uses magik-utils-get-buffer-mode fails.

This new functionality is put behind a customization option so that users can choose which behaviour they want. And to not interrupt people's current workflow.