### PR TITLE
CI: drop MacOS-11, bump Emacs 29.x to 29.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         - os: ubuntu-latest
           emacs-version: 27.2
           experimental: false
-        - os: macos-11
+        - os: macos-12
           emacs-version: 27.2
           experimental: false
         - os: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,29 +20,23 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         emacs-version:
+          - 27.2
           - 28.2
-          - 29.2
-          - 29.3
+          - 29.4
         experimental: [false]
         include:
-        - os: ubuntu-latest
-          emacs-version: 27.2
-          experimental: false
-        - os: macos-12
-          emacs-version: 27.2
-          experimental: false
-        - os: windows-latest
-          emacs-version: 27.2
-          experimental: false
-        - os: ubuntu-latest
-          emacs-version: snapshot
-          experimental: true
-        - os: macos-latest
-          emacs-version: snapshot
-          experimental: true
-        - os: windows-latest
-          emacs-version: snapshot
-          experimental: true
+          - os: ubuntu-latest
+            emacs-version: snapshot
+            experimental: true
+          - os: macos-latest
+            emacs-version: snapshot
+            experimental: true
+          - os: windows-latest
+            emacs-version: snapshot
+            experimental: true
+        exclude:
+          - os: macos-latest
+            emacs-version: 27.2
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
MacOS-11 image is dropped since June; another solution is to use MacOS-12, but that is a short-term solution as that image will be deleted over time as well.

https://github.com/purcell/nix-emacs-ci/pull/268
https://github.com/purcell/setup-emacs/issues/48
