### PR TITLE
[magik-treesit] Add correct indent rule for `_finally`

### DIFF
--- a/magik-treesit.el
+++ b/magik-treesit.el
@@ -126,6 +126,7 @@
      ((parent-is "else") parent magik-indent-level)
      ((parent-is "iterator") parent magik-indent-level)
      ((parent-is "loop") parent magik-indent-level)
+     ((parent-is "finally") parent magik-indent-level)
      ((parent-is "while") parent magik-indent-level)
      ((parent-is "method") parent magik-indent-level)
      ((parent-is "protect") parent magik-indent-level)


### PR DESCRIPTION
Fix indent rule for _finally to indent the next snippet to:
```
_loop
    <do_something>
_finally
    <do_something>
_endloop
```
instead of:

```
_loop
    <do_something>
_finally
<do_something>
_endloop
```