### PR TITLE
[magik-session] Fix command history in sequential Magik sessions

### DIFF
--- a/magik-session.el
+++ b/magik-session.el
@@ -528,64 +528,64 @@ Entry to this mode runs `magik-session-mode-hook`.
   :group 'magik
   :syntax-table magik-base-mode-syntax-table
 
-    (compat-call setq-local
-                 selective-display t
-                 comint-last-input-start (make-marker)
-                 comint-last-input-end (make-marker)
-                 magik-session-command-history (or magik-session-command-history
-                                                   (default-value 'magik-session-command-history))
-                 magik-session-filter-state "\C-a"
-                 magik-session-cb-buffer (concat "*cb*" (buffer-name))
-                 magik-session-cmd-num magik-session-cmd-num
-                 magik-session-drag-n-drop-mode-line-string " DnD"
-                 magik-session-no-of-cmds magik-session-no-of-cmds
-                 magik-session-prev-cmds magik-session-prev-cmds
-                 magik-transmit-debug-mode-line-string " #DEBUG"
-                 show-trailing-whitespace nil
-                 font-lock-defaults '(magik-session-font-lock-keywords nil t ((?_ . "w")))
-                 ac-sources (append '(magik-ac-class-method-source
-                                      magik-ac-dynamic-source
-                                      magik-ac-global-source
-                                      magik-ac-object-source
-                                      magik-ac-raise-condition-source)
-                                    ac-sources)
-                 magik-session-exec-path (cl-copy-list (or magik-session-exec-path exec-path))
-                 magik-session-process-environment (cl-copy-list (or magik-session-process-environment process-environment))
-                 mode-line-process '(": %s")
-                 local-abbrev-table magik-base-mode-abbrev-table)
+  (compat-call setq-local
+               selective-display t
+               comint-last-input-start (make-marker)
+               comint-last-input-end (make-marker)
+               magik-session-command-history (or magik-session-command-history
+                                                 (default-value 'magik-session-command-history))
+               magik-session-filter-state "\C-a"
+               magik-session-cb-buffer (concat "*cb*" (buffer-name))
+               magik-session-cmd-num magik-session-cmd-num
+               magik-session-drag-n-drop-mode-line-string " DnD"
+               magik-session-no-of-cmds magik-session-no-of-cmds
+               magik-session-prev-cmds magik-session-prev-cmds
+               magik-transmit-debug-mode-line-string " #DEBUG"
+               show-trailing-whitespace nil
+               font-lock-defaults '(magik-session-font-lock-keywords nil t ((?_ . "w")))
+               ac-sources (append '(magik-ac-class-method-source
+                                    magik-ac-dynamic-source
+                                    magik-ac-global-source
+                                    magik-ac-object-source
+                                    magik-ac-raise-condition-source)
+                                  ac-sources)
+               magik-session-exec-path (cl-copy-list (or magik-session-exec-path exec-path))
+               magik-session-process-environment (cl-copy-list (or magik-session-process-environment process-environment))
+               mode-line-process '(": %s")
+               local-abbrev-table magik-base-mode-abbrev-table)
 
   (unless magik-session-no-of-cmds
-          (compat-call setq-local
-                       magik-session-no-of-cmds 1
-                       magik-session-cmd-num 0
-                       magik-session-prev-cmds (make-vector 100 nil))
-          (aset magik-session-prev-cmds 0 (let ((m (point-min-marker))) (cons m m))))
+    (compat-call setq-local
+                 magik-session-no-of-cmds 1
+                 magik-session-cmd-num 0
+                 magik-session-prev-cmds (make-vector 100 nil))
+    (aset magik-session-prev-cmds 0 (let ((m (point-min-marker))) (cons m m))))
 
-    (unless (and magik-session-buffer (get-buffer magik-session-buffer))
-      (setq-default magik-session-buffer (buffer-name)))
+  (unless (and magik-session-buffer (get-buffer magik-session-buffer))
+    (setq-default magik-session-buffer (buffer-name)))
 
-    (unless (rassoc (buffer-name) magik-session-buffer-alist)
-      (let ((n 1))
-        (while (cdr (assq n magik-session-buffer-alist))
-          (setq n (1+ n)))
-        (if (assq n magik-session-buffer-alist)
-            (setcdr (assq n magik-session-buffer-alist) (buffer-name))
-          (add-to-list 'magik-session-buffer-alist (cons n (buffer-name))))))
+  (unless (rassoc (buffer-name) magik-session-buffer-alist)
+    (let ((n 1))
+      (while (cdr (assq n magik-session-buffer-alist))
+        (setq n (1+ n)))
+      (if (assq n magik-session-buffer-alist)
+          (setcdr (assq n magik-session-buffer-alist) (buffer-name))
+        (add-to-list 'magik-session-buffer-alist (cons n (buffer-name))))))
 
-    ;; Special handling for *gis* buffer
-    (if (equal (buffer-name) "*gis*")
-        (compat-call setq-local
-                     magik-session-exec-path (cl-copy-list exec-path)
-                     magik-session-process-environment (cl-copy-list process-environment)))
+  ;; Special handling for *gis* buffer
+  (if (equal (buffer-name) "*gis*")
+      (compat-call setq-local
+                   magik-session-exec-path (cl-copy-list exec-path)
+                   magik-session-process-environment (cl-copy-list process-environment)))
 
-    (abbrev-mode 1)
+  (abbrev-mode 1)
 
-    (with-current-buffer (get-buffer-create (concat " *filter*" (buffer-name)))
-      (erase-buffer))
+  (with-current-buffer (get-buffer-create (concat " *filter*" (buffer-name)))
+    (erase-buffer))
 
-    (add-hook 'menu-bar-update-hook 'magik-session-update-magik-session-menu nil t)
-    (add-hook 'menu-bar-update-hook 'magik-session-update-tools-magik-gis-menu nil t)
-    (add-hook 'menu-bar-update-hook 'magik-session-update-tools-magik-shell-menu nil t)
+  (add-hook 'menu-bar-update-hook 'magik-session-update-magik-session-menu nil t)
+  (add-hook 'menu-bar-update-hook 'magik-session-update-tools-magik-gis-menu nil t)
+  (add-hook 'menu-bar-update-hook 'magik-session-update-tools-magik-shell-menu nil t)
   (add-hook 'kill-buffer-hook 'magik-session-buffer-alist-remove nil t))
 
 (defvar magik-session-menu nil
@@ -792,7 +792,7 @@ there is not, prompt for a command to run, and then run it."
 
       (pop-to-buffer (get-buffer-create buffer))
       (unless (eq major-mode 'magik-session-mode)
-	(magik-session-mode))
+        (magik-session-mode))
       (goto-char (point-max))
       (insert "\n" (current-time-string) "\n")
       (setq default-directory (expand-file-name

--- a/magik-session.el
+++ b/magik-session.el
@@ -516,17 +516,12 @@ and return a list of all the components of the command."
 
 (define-derived-mode magik-session-mode nil "Magik Session"
   "Major mode to run a GIS as a direct subprocess.
-
 The default name for a buffer running a GIS is \"*gis*\". The name of
 the current GIS buffer is stored in the user option `magik-session-buffer`.
-
 There are many ways to recall previous commands (see the online
 help with \\[help-command]).
-
 Commands are sent to the GIS with the F8 key or the return key.
-
 Entry to this mode runs `magik-session-mode-hook`.
-
 \\{magik-session-mode-map}"
   :group 'magik
   :syntax-table magik-base-mode-syntax-table
@@ -564,10 +559,17 @@ Entry to this mode runs `magik-session-mode-hook`.
                  magik-session-prev-cmds (make-vector 100 nil))
     (aset magik-session-prev-cmds 0 (let ((m (point-min-marker))) (cons m m))))
 
-  (abbrev-mode 1)
+  (unless (and magik-session-buffer (get-buffer magik-session-buffer))
+    (setq-default magik-session-buffer (buffer-name)))
 
-  (with-current-buffer (get-buffer-create (concat " *filter*" (buffer-name)))
-    (erase-buffer))
+  (unless (rassoc (buffer-name) magik-session-buffer-alist)
+    (let ((n 1))
+      (while (cdr (assq n magik-session-buffer-alist))
+        (setq n (1+ n)))
+      (if (assq n magik-session-buffer-alist)
+          (setcdr (assq n magik-session-buffer-alist) (buffer-name))
+        (add-to-list 'magik-session-buffer-alist (cons n (buffer-name))))))
+
   ;; Special handling for *gis* buffer
   (if (equal (buffer-name) "*gis*")
       (compat-call setq-local

--- a/magik-session.el
+++ b/magik-session.el
@@ -230,16 +230,19 @@ this variable buffer-local by putting the following in your .emacs
   "No. of commands we have sent to this buffer's gis including the
 null one at the end, but excluding commands that have been spotted as
 being degenerate.")
+(put 'magik-session-no-of-cmds 'permanent-local t)
 
 (defvar magik-session-cmd-num nil
   "A number telling us what command is being recalled.  Important for
 M-p and M-n commands.  The first command typed is number 0.  The
 current command being typed is number (1- magik-session-no-of-cmds).")
+(put 'magik-session-cmd-num 'permanent-local t)
 
 (defvar magik-session-prev-cmds nil
   "A vector of pairs of markers, oldest commands first.  Every time
 the vector fills up, we copy to a new vector and clean out naff
 markers.")
+(put 'magik-session-prev-cmds 'permanent-local t)
 
 (defvar magik-session-history-length 20
   "The default number of commands to fold.")
@@ -561,17 +564,10 @@ Entry to this mode runs `magik-session-mode-hook`.
                  magik-session-prev-cmds (make-vector 100 nil))
     (aset magik-session-prev-cmds 0 (let ((m (point-min-marker))) (cons m m))))
 
-  (unless (and magik-session-buffer (get-buffer magik-session-buffer))
-    (setq-default magik-session-buffer (buffer-name)))
+  (abbrev-mode 1)
 
-  (unless (rassoc (buffer-name) magik-session-buffer-alist)
-    (let ((n 1))
-      (while (cdr (assq n magik-session-buffer-alist))
-        (setq n (1+ n)))
-      (if (assq n magik-session-buffer-alist)
-          (setcdr (assq n magik-session-buffer-alist) (buffer-name))
-        (add-to-list 'magik-session-buffer-alist (cons n (buffer-name))))))
-
+  (with-current-buffer (get-buffer-create (concat " *filter*" (buffer-name)))
+    (erase-buffer))
   ;; Special handling for *gis* buffer
   (if (equal (buffer-name) "*gis*")
       (compat-call setq-local


### PR DESCRIPTION
Also show an error if there is no active process running in the buffer when trying to scroll through the commands history.