### PR TITLE
[magik-lint] Bump the Magik linter to 0.10.1

### DIFF
--- a/magik-lint.el
+++ b/magik-lint.el
@@ -32,7 +32,7 @@
         (cdr (assoc 'tag_name response))))))
 
 (defcustom magik-lint-jar-file-version
-  (or (magik-lint--latest-version) "0.9.1")
+  (or (magik-lint--latest-version) "0.10.1")
   "Version of magik-lint to use."
   :group 'magik
   :type 'string)


### PR DESCRIPTION
Release: https://github.com/StevenLooman/magik-tools/releases/tag/0.10.1
Change log: https://github.com/StevenLooman/magik-tools/blob/develop/CHANGES.md?plain=1#L56

CC: @StevenLooman