### PR TITLE
[magik-version] Stop setting `SMALLWORLD_GIS`

### DIFF
--- a/magik-aliases.el
+++ b/magik-aliases.el
@@ -327,7 +327,7 @@ With a prefix arg, ask user for current directory to use."
 
 (defun magik-aliases-expand-file (file smallworld-gis)
   "Expand FILE path including environment variables using SMALLWORLD-GIS.
-Returns nil if FILE cannot be expanded."
+Returns nil if FILE can't be expanded."
   (condition-case nil
       (with-environment-variables (("SMALLWORLD_GIS" smallworld-gis))
         (expand-file-name

--- a/magik-aliases.el
+++ b/magik-aliases.el
@@ -142,7 +142,6 @@ You can customise magik-aliases-mode with the magik-aliases-mode-hook.
                comment-start "#"
                comment-end ""
                show-trailing-whitespace nil
-               magik-aliases-program (magik-aliases-program-set magik-aliases-program)
                imenu-generic-expression magik-aliases-imenu-generic-expression
                font-lock-defaults '(magik-aliases-font-lock-keywords nil nil))
 
@@ -245,6 +244,7 @@ when the buffer is displayed:
 (defun magik-aliases-program-set (&optional default)
   "Return the program to use to operate on a gis_aliases file."
   (let ((path magik-aliases-program-path)
+        (smallworld-gis magik-smallworld-gis)
         program)
     (while path
       (setq program (expand-file-name
@@ -255,7 +255,7 @@ when the buffer is displayed:
         (setq program nil)))
     (unless program
       (setq program (expand-file-name
-                     (concat (getenv "SMALLWORLD_GIS") "/config/"
+                     (concat smallworld-gis "/config/"
                              (file-name-as-directory (car magik-aliases-program-path)) magik-aliases-program)))
       (unless (file-executable-p program)
         (setq program nil)))
@@ -280,7 +280,7 @@ With a prefix arg, ask user for current directory to use."
         ((null dir)
          (setq dir default-directory)))
 
-  (let ((program magik-aliases-program)
+  (let ((program (magik-aliases-program-set magik-aliases-program))
         (args    magik-aliases-program-args)
         (file    (or file (buffer-file-name)))
         (buf     "gis")

--- a/magik-aliases.el
+++ b/magik-aliases.el
@@ -224,7 +224,7 @@ You can customise magik-aliases-mode with the magik-aliases-mode-hook.
   "Return t, to switch to the buffer that the GIS.exe process is running in.
 Since some entries in the aliases file do not start a Smallworld Magik GIS
 process we do not necessarily want to switch to the buffer running the
-process all the time. These are the following methods by which we control
+process all the time.  These are the following methods by which we control
 when the buffer is displayed:
   Hook: `aliases-switch-to-buffer-hooks'
        Each function in the hook is passed the name of the alias.
@@ -233,8 +233,7 @@ when the buffer is displayed:
        If the alias name matches the given regular expression the buffer
        is displayed.
   Variable: `aliases-switch-to-buffer'
-       If this is t then the buffer is displayed.
-"
+       If this is t then the buffer is displayed."
   (cond ((run-hook-with-args-until-success 'magik-aliases-switch-to-buffer-hooks alias)
          t)
         ((stringp magik-aliases-switch-to-buffer-regexp)
@@ -495,7 +494,7 @@ configuration file and return paths to append to variable `exec-path'."
 
 ;;MSB configuration
 (defun magik-aliases-msb-configuration ()
-  "Adds Aliases files to msb menu, supposes that msb is already loaded."
+  "Add Aliases files to msb menu, supposes that msb is already loaded."
   (let* ((l (length msb-menu-cond))
          (last (nth (1- l) msb-menu-cond))
          (precdr (nthcdr (- l 2) msb-menu-cond)) ; cdr of this is last

--- a/magik-aliases.el
+++ b/magik-aliases.el
@@ -271,7 +271,7 @@ With a prefix arg, ask user for current directory to use."
         ((null dir)
          (setq dir default-directory)))
 
-  (let* ((smallworld-gis (buffer-local-value 'magik-smallworld-gis (current-buffer)))
+  (let* ((smallworld-gis magik-smallworld-gis)
          (program (magik-aliases-program smallworld-gis))
          (args    magik-aliases-program-args)
          (file    (or file (buffer-file-name)))
@@ -436,7 +436,7 @@ configuration file and return paths to append to variable `exec-path'."
         lp-files
         buffers
         (rescan (list "---" (vector "*Rescan*" 'magik-aliases-update-sw-menu t)))
-        (smallworld-gis (buffer-local-value 'magik-smallworld-gis (current-buffer))))
+        (smallworld-gis magik-smallworld-gis))
     (dolist (f (append magik-aliases-user-file-list magik-aliases-common-file-list ))
       (push `[,f
               (progn

--- a/magik-aliases.el
+++ b/magik-aliases.el
@@ -40,7 +40,7 @@
   "*List of common gis_aliases files.
 This list is expected to be setup by the Emacs maintainer,
 a user can setup their personal gis_aliases file list using
-`aliases-user-file-list'.  Both these lists are concatenated to
+`magik-aliases-user-file-list'.  Both these lists are concatenated to
 form the top section of the SW->Alias Files submenu."
   :group 'magik-aliases
   :type  '(repeat file))
@@ -51,7 +51,7 @@ form the top section of the SW->Alias Files submenu."
   :type  'string)
 
 (defcustom magik-aliases-program-path '("../bin/x86" "../../product/bin/x86")
-  "*Path to `aliases-program'.
+  "*Path to `magik-aliases-program'.
 Setting this sets the default value.  When opening a gis_aliases file,
 the buffer local value of this variable will be set to the directory
 containing the `magik-aliases-program' if it is in a relative path to the file."
@@ -94,7 +94,7 @@ If any function returns t, then the buffer is displayed."
   :type  'hook)
 
 (defvar magik-aliases-definition-regexp "^\\([^#]\\S-+\\):\\s-*$"
-  "Regexp matching an alias definition")
+  "Regexp matching an alias definition.")
 
 ;; Imenu configuration
 (defvar magik-aliases-imenu-generic-expression
@@ -437,7 +437,7 @@ LAYERED_PRODUCTS configuration file and return paths to append to `exec-path'."
                           "Definitions"
                           (or entries (list "No Aliases found"))))))
 
-(defun magik-aliases-update-sw-menu ()
+(defun magik-aliases-update-sw-menu () ;; TODO: Use magik-smallworld-gis
   "Update `Alias Files' submenu in SW menu bar."
   (interactive)
   (let (default-files

--- a/magik-cb.el
+++ b/magik-cb.el
@@ -538,7 +538,9 @@ Do a no-op if already in the cb."
 
       (if (not running-p)
           (progn
-            (compat-call setq-local magik-cb-process (magik-cb-get-process-create buffer 'magik-cb-filter smallworld-gis gis magik-cb-file))
+            (compat-call setq-local
+                         magik-cb-process (magik-cb-get-process-create buffer 'magik-cb-filter smallworld-gis gis magik-cb-file)
+                         magik-smallworld-gis smallworld-gis)
             (magik-cb-interactive-buffer)
             (sleep-for 0.1)))
 
@@ -2384,29 +2386,30 @@ Introduce or remove drive names.
 
 See the variable `magik-cb-generalise-file-name-alist' to provide more customisation."
   (save-match-data
-    (setq f (substitute-in-file-name f))
-    (if magik-cb-generalise-file-name-alist
-        (progn
-          (subst-char-in-string ?\\ ?/ f t)
-          (cl-loop for i in magik-cb-generalise-file-name-alist
-                   if (and (string-match (car i) f)
-                           (setq f (replace-match (cdr i) nil t f)))
-                   return f)))
-    (if (eq system-type 'windows-nt)
-        (progn
-          (subst-char-in-string ?/ ?\\ f t)
-          (if (or (string-match "^[a-zA-Z]:" f)
-                  (string-match "^\\\\\\\\" f))
-              f
-            (let* ((buffer (magik-cb-gis-buffer))
-                   (drive-name (if (get-buffer buffer)
-                                   (with-current-buffer buffer
-                                     (substring default-directory 0 2))
-                                 (substring default-directory 0 2))))
-              (concat drive-name f))))
-      (if (string-match "^[a-zA-Z]:" f)
-          (setq f (substring f 2)))
-      (subst-char-in-string ?\\ ?/ f t))))
+    (with-environment-variables (("SMALLWORLD_GIS" magik-smallworld-gis))
+      (setq f (substitute-in-file-name f))
+      (if magik-cb-generalise-file-name-alist
+          (progn
+            (subst-char-in-string ?\\ ?/ f t)
+            (cl-loop for i in magik-cb-generalise-file-name-alist
+                     if (and (string-match (car i) f)
+                             (setq f (replace-match (cdr i) nil t f)))
+                     return f)))
+      (if (eq system-type 'windows-nt)
+          (progn
+            (subst-char-in-string ?/ ?\\ f t)
+            (if (or (string-match "^[a-zA-Z]:" f)
+                    (string-match "^\\\\\\\\" f))
+                f
+              (let* ((buffer (magik-cb-gis-buffer))
+                     (drive-name (if (get-buffer buffer)
+                                     (with-current-buffer buffer
+                                       (substring default-directory 0 2))
+                                   (substring default-directory 0 2))))
+                (concat drive-name f))))
+        (if (string-match "^[a-zA-Z]:" f)
+            (setq f (substring f 2)))
+        (subst-char-in-string ?\\ ?/ f t)))))
 
 (defun magik-cb-disable-save ()
   "Like `save-buffer', but does nothing in magik-cb."

--- a/magik-cb.el
+++ b/magik-cb.el
@@ -784,7 +784,7 @@ BUFFER may be nil, in which case only the process is started."
 (defun magik-cb-get-process-create (buffer filter smallworld-gis &optional gis cb-file)
   "Return a method finder process in BUFFER using SMALLWORLD-GIS.
 Creating one using GIS buffer or CB_FILE if needed.
-Either starts a method_finder process or if a GIS session is running
+Either starts a method_finder process or if a Magik session is running
 it starts a mf_connector process to communicate with the method_finder in GIS.
 If FILTER is given then it is set on the process."
   (setq buffer (get-buffer-create buffer)) ; get a real buffer object.
@@ -824,7 +824,7 @@ If FILTER is given then it is set on the process."
                                                                                       (number-to-string (point-max)))))
              (magik-cb-send-load cb-file))
             (t
-             (error "Cannot start CB")))
+             (error "Can't start CB")))
 
       (when magik-cb-process
         (save-excursion

--- a/magik-cb.el
+++ b/magik-cb.el
@@ -523,7 +523,7 @@ Do a no-op if already in the cb."
                  gis    (magik-cb-gis-buffer buffer))))
 
     (setq buffer   (or buffer (concat "*cb*" gis))
-          smallworld-gis (buffer-local-value 'magik-smallworld-gis (get-buffer gis))
+          smallworld-gis (buffer-local-value 'magik-smallworld-gis (get-buffer buffer))
           gis-proc (and gis (get-buffer-process gis)))
 
     (cond ((magik-cb-is-running buffer)

--- a/magik-cb.el
+++ b/magik-cb.el
@@ -781,7 +781,7 @@ BUFFER may be nil, in which case only the process is started."
 
 (defun magik-cb-get-process-create (buffer filter smallworld-gis &optional gis cb-file)
   "Return a method finder process in BUFFER using SMALLWORLD-GIS.
-Creating one using GIS buffer or CB_FILE if needed.
+Creating one using Magik session buffer or CB_FILE if needed.
 Either starts a method_finder process or if a Magik session is running
 it starts a mf_connector process to communicate with the method_finder in GIS.
 If FILTER is given then it is set on the process."

--- a/magik-cb.el
+++ b/magik-cb.el
@@ -2384,32 +2384,31 @@ Turn slash characters around.
 Expand either $foo or %foo% variables
 Introduce or remove drive names.
 
-See the variable `magik-cb-generalise-file-name-alist' to provide more customisation."
+See the variable `magik-cb-generalise-file-name-alist' for more customisation."
   (save-match-data
-    (with-environment-variables (("SMALLWORLD_GIS" magik-smallworld-gis))
-      (setq f (substitute-in-file-name f))
-      (if magik-cb-generalise-file-name-alist
-          (progn
-            (subst-char-in-string ?\\ ?/ f t)
-            (cl-loop for i in magik-cb-generalise-file-name-alist
-                     if (and (string-match (car i) f)
-                             (setq f (replace-match (cdr i) nil t f)))
-                     return f)))
-      (if (eq system-type 'windows-nt)
-          (progn
-            (subst-char-in-string ?/ ?\\ f t)
-            (if (or (string-match "^[a-zA-Z]:" f)
-                    (string-match "^\\\\\\\\" f))
-                f
-              (let* ((buffer (magik-cb-gis-buffer))
-                     (drive-name (if (get-buffer buffer)
-                                     (with-current-buffer buffer
-                                       (substring default-directory 0 2))
-                                   (substring default-directory 0 2))))
-                (concat drive-name f))))
-        (if (string-match "^[a-zA-Z]:" f)
-            (setq f (substring f 2)))
-        (subst-char-in-string ?\\ ?/ f t)))))
+    (setq f (with-environment-variables (("SMALLWORLD_GIS" magik-smallworld-gis))
+              (substitute-in-file-name f)))
+    (when magik-cb-generalise-file-name-alist
+      (subst-char-in-string ?\\ ?/ f t)
+      (cl-loop for i in magik-cb-generalise-file-name-alist
+               if (and (string-match (car i) f)
+                       (setq f (replace-match (cdr i) nil t f)))
+               return f))
+    (if (eq system-type 'windows-nt)
+        (progn
+          (subst-char-in-string ?/ ?\\ f t)
+          (if (or (string-match "^[a-zA-Z]:" f)
+                  (string-match "^\\\\\\\\" f))
+              f
+            (let* ((buffer (magik-cb-gis-buffer))
+                   (drive-name (if (get-buffer buffer)
+                                   (with-current-buffer buffer
+                                     (substring default-directory 0 2))
+                                 (substring default-directory 0 2))))
+              (concat drive-name f))))
+      (if (string-match "^[a-zA-Z]:" f)
+          (setq f (substring f 2)))
+      (subst-char-in-string ?\\ ?/ f t))))
 
 (defun magik-cb-disable-save ()
   "Like `save-buffer', but does nothing in magik-cb."

--- a/magik-cb.el
+++ b/magik-cb.el
@@ -770,10 +770,15 @@ If `cb-process' is not nil, returns that irrespective of given BUFFER."
     (if (and (stringp magik-cb--mf-socket-synchronised) (not (equal magik-cb--mf-socket-synchronised "")))
         magik-cb--mf-socket-synchronised)))
 
+(defun magik-cb--acp-paths ()
+  "Return the ACP paths."
+  (magik-aliases-layered-products-acp-path
+   (magik-aliases-expand-file magik-aliases-layered-products-file magik-smallworld-gis) magik-smallworld-gis))
+
 (defun magik-cb-start-process (buffer command &rest args)
   "Start a COMMAND process in BUFFER and return process object.
 BUFFER may be nil, in which case only the process is started."
-  (let* ((exec-path (append (magik-aliases-layered-products-acp-path (magik-aliases-expand-file magik-aliases-layered-products-file)) exec-path))
+  (let* ((exec-path (append (magik-cb--acp-paths) exec-path))
          magik-cb-process)
     (compat-call setq-local magik-cb-process (apply 'start-process "cb" buffer command args))
     (set-process-filter        magik-cb-process 'magik-cb-filter)
@@ -800,6 +805,8 @@ If FILTER is given then it is set on the process."
                                       (or (symbol-value 'magik-session-exec-path) exec-path))))
            (gis-proc (and gis (get-buffer-process gis)))
            magik-cb-process)
+
+      (setq magik-smallworld-gis (buffer-local-value 'magik-smallworld-gis (get-buffer gis)))
 
       (cond (gis-proc
              ;; then ask Magik to start a method_finder.  Magik will
@@ -2349,7 +2356,7 @@ comments etc."
 
 (defun magik-cb-method-finder-version ()
   "Return as a string (e.g. \"2.0.0\") the version of the method_finder."
-  (let* ((exec-path (append (magik-aliases-layered-products-acp-path (magik-aliases-expand-file magik-aliases-layered-products-file)) exec-path))
+  (let* ((exec-path (append (magik-cb--acp-paths) exec-path))
          magik-cb-process)
     (with-current-buffer (get-buffer-create " *method finder version*")
       (erase-buffer)

--- a/magik-cb.el
+++ b/magik-cb.el
@@ -523,7 +523,9 @@ Do a no-op if already in the cb."
                  gis    (magik-cb-gis-buffer buffer))))
 
     (setq buffer   (or buffer (concat "*cb*" gis))
-          smallworld-gis (buffer-local-value 'magik-smallworld-gis (get-buffer buffer))
+          smallworld-gis (cond
+                          (gis (buffer-local-value 'magik-smallworld-gis (get-buffer gis)))
+                          (buffer (buffer-local-value 'magik-smallworld-gis (get-buffer buffer))))
           gis-proc (and gis (get-buffer-process gis)))
 
     (cond ((magik-cb-is-running buffer)

--- a/magik-mode.el
+++ b/magik-mode.el
@@ -82,6 +82,9 @@ Users can also swap the point and mark positions using \\[exchange-point-and-mar
   :group 'magik
   :type  'integer)
 
+(defvar-local magik-smallworld-gis nil
+  "Stores the current SMALLWORLD_GIS.")
+
 (define-derived-mode magik-base-mode prog-mode "Magik"
   "Generic major mode for editing Magik files.
 

--- a/magik-session.el
+++ b/magik-session.el
@@ -216,13 +216,11 @@ this variable buffer-local by putting the following in your .emacs
 (defvar magik-session-current-command nil
   "The current `magik-session-command' in the current buffer.")
 
-(defvar magik-session-exec-path nil
-  "Stored value of `exec-path' when the GIS process was started.")
-(make-variable-buffer-local 'magik-session-exec-path)
+(defvar-local magik-session-exec-path nil
+  "Stored value of variable `exec-path' when the GIS process was started.")
 
-(defvar magik-session-process-environment nil
+(defvar-local magik-session-process-environment nil
   "Stored value of `process-environment' when the GIS process was started.")
-(make-variable-buffer-local 'magik-session-process-environment)
 
 (defvar magik-session-cb-buffer nil
   "The Class browser buffer associated with the GIS process.")

--- a/magik-session.el
+++ b/magik-session.el
@@ -334,13 +334,17 @@ queried irrespective of default value of `magik-session-prompt'"
   (interactive)
   (require 'shell)
   (let ((buffer (concat "*shell*" (buffer-name)))
-        (version (and (boundp 'magik-session-version-current) (symbol-value 'magik-session-version-current))))
+        (version (and (boundp 'magik-version-current)
+                      (symbol-value 'magik-version-current)))
+        (smallworld-gis magik-smallworld-gis))
     (make-comint-in-buffer "magik-session-shell"
                            buffer
                            (executable-find "cmd") nil "/k"
-                           (concat (getenv "SMALLWORLD_GIS") "\\config\\environment.bat"))
+                           (expand-file-name "environment.bat" (file-name-concat smallworld-gis "config")))
     (with-current-buffer buffer
-      (if (stringp version) (set 'magik-session-version-current version)))
+      (when (stringp version)
+        (set 'magik-version-current version))
+      (set 'magik-smallworld-gis smallworld-gis))
     (display-buffer buffer)))
 
 (defun magik-session-parse-gis-command (command)
@@ -485,7 +489,7 @@ Return a list of all the components of the COMMAND."
 (defun magik-session-update-tools-magik-shell-menu ()
   "Update External Shell Processes submenu in Tools -> Magik pulldown menu."
   (let ((shell-bufs (magik-utils-buffer-mode-list 'shell-mode
-                                                  (function (lambda () (getenv "SMALLWORLD_GIS")))))
+                                                  (function (lambda () (symbol-value 'magik-smallworld-gis)))))
         shell-list)
     (cl-loop for buf in shell-bufs
              do (push (vector buf (list 'display-buffer buf) t) shell-list))

--- a/magik-session.el
+++ b/magik-session.el
@@ -216,12 +216,6 @@ this variable buffer-local by putting the following in your .emacs
 (defvar magik-session-current-command nil
   "The current `magik-session-command' in the current buffer.")
 
-(defvar-local magik-session-exec-path nil
-  "Stored value of variable `exec-path' when the GIS process was started.")
-
-(defvar-local magik-session-process-environment nil
-  "Stored value of `process-environment' when the GIS process was started.")
-
 (defvar magik-session-cb-buffer nil
   "The Class browser buffer associated with the GIS process.")
 
@@ -336,9 +330,7 @@ queried irrespective of default value of `magik-session-prompt'"
   "Start a command shell with the same environment as the current GIS process."
   (interactive)
   (require 'shell)
-  (let ((process-environment (cl-copy-list magik-session-process-environment))
-        (exec-path (cl-copy-list magik-session-exec-path))
-        (buffer (concat "*shell*" (buffer-name)))
+  (let ((buffer (concat "*shell*" (buffer-name)))
         (version (and (boundp 'magik-session-version-current) (symbol-value 'magik-session-version-current))))
     (make-comint-in-buffer "magik-session-shell"
                            buffer
@@ -531,8 +523,6 @@ Entry to this mode runs `magik-session-mode-hook`.
                                     magik-ac-object-source
                                     magik-ac-raise-condition-source)
                                   ac-sources)
-               magik-session-exec-path (cl-copy-list (or magik-session-exec-path exec-path))
-               magik-session-process-environment (cl-copy-list (or magik-session-process-environment process-environment))
                mode-line-process '(": %s")
                local-abbrev-table magik-base-mode-abbrev-table)
 
@@ -553,12 +543,6 @@ Entry to this mode runs `magik-session-mode-hook`.
       (if (assq n magik-session-buffer-alist)
           (setcdr (assq n magik-session-buffer-alist) (buffer-name))
         (add-to-list 'magik-session-buffer-alist (cons n (buffer-name))))))
-
-  ;; Special handling for *gis* buffer
-  (if (equal (buffer-name) "*gis*")
-      (compat-call setq-local
-                   magik-session-exec-path (cl-copy-list exec-path)
-                   magik-session-process-environment (cl-copy-list process-environment)))
 
   (abbrev-mode 1)
 

--- a/magik-template.el
+++ b/magik-template.el
@@ -96,7 +96,7 @@ you will also have to add an appropriate entry to
 magik-template-file-type-alist to make the user
 selection pick up the new template file.")
 
-(defvar magik-template-file-type nil
+(defvar-local magik-template-file-type nil
   "Type of Magik file being edited.
 This variable is buffer local and is used to identify the type of magik file it is,
 i.e. which Template file it came from.
@@ -104,7 +104,6 @@ i.e. which Template file it came from.
 The default value of this variable is used for communicating the type of
 template the user wants when the buffer/file does not exist to the `file-not-found-hook'
 function \\[magik-template-maybe-insert].")
-(make-variable-buffer-local 'magik-template-file-type)
 
 (defvar magik-template-file-type-templates-default '((default "Default" "template_default.magik"))
   "Default list for \\[magik-template-file-type-alist-add].

--- a/magik-version.el
+++ b/magik-version.el
@@ -94,9 +94,8 @@ This provides an alternative interface to a gis_version program."
 (defvar magik-version-sw-path-list nil
   "Stores list of Smallworld directories added to PATH.")
 
-(defvar magik-version-current nil
+(defvar-local magik-version-current nil
   "Current gis_version stream.")
-(make-variable-buffer-local 'magik-version-current)
 
 (defvar magik-version-position nil
   "A position in the gis version buffer above which the user shouldn't click.")

--- a/magik-version.el
+++ b/magik-version.el
@@ -110,9 +110,10 @@ This provides an alternative interface to a gis_version program."
   "Run GIS command in selected version."
   (interactive)
   (beginning-of-line)
-  (let (stream version buffer)
-    (setq stream (car (magik-version-at-version-definition))
-          buffer  (concat "*gis " stream "*"))
+  (let* ((definition (magik-version-at-version-definition))
+         (stream (nth 0 definition))
+         (buffer (concat "*gis " stream "*")))
+    (magik-version--set-environment definition)
     (magik-session buffer)
     (setq magik-version-current stream)))
 

--- a/magik-version.el
+++ b/magik-version.el
@@ -111,7 +111,7 @@ This provides an alternative interface to a gis_version program."
   (interactive)
   (beginning-of-line)
   (let (stream version buffer)
-    (setq stream (car (magik-version-select-internal))
+    (setq stream (car (magik-version--select-internal))
           buffer  (concat "*gis " stream "*"))
     (magik-session buffer)
     (setq magik-version-current stream)))
@@ -123,7 +123,7 @@ has more than one aliases file available."
   ;;Does not cope with 'partial stream versions' where the directory components list 2 (or more directories)
   (interactive)
   (beginning-of-line)
-  (let* ((version-list (magik-version-select-internal))
+  (let* ((version-list (magik-version--select-internal))
          lp-alist
          alias-file)
     (if (null (car version-list))
@@ -181,7 +181,7 @@ has more than one aliases file available."
                buffer-undo-list t
                font-lock-defaults '(magik-version-font-lock-keywords nil t (("-" . "w"))))
 
-  (add-hook 'menu-bar-update-hook 'magik-versions-update-menu nil t))
+  (add-hook 'menu-bar-update-hook #'magik-versions-update-menu nil t))
 
 (defvar magik-version-menu nil
   "Keymap for the gis_version buffer menu bar.")
@@ -202,7 +202,7 @@ has more than one aliases file available."
     "---"
     [,"Customize"                 magik-version-customize   t]))
 
-(add-hook 'magik-version-select-hook  'magik-aliases-update-menu)
+(add-hook 'magik-version-select-hook #'magik-aliases-update-menu)
 
 (defun magik-version-smallworld-gis-p (path)
   "Return t if path points to a Smallworld installation."
@@ -377,43 +377,56 @@ Will set `gis-version-file' to FILE."
   (beginning-of-line)
   (magik-version-select))
 
-(defun magik-version-select ()
+(defun magik-version-select (&optional selected-stream)
   "Store the gis product name in the global variable `gis-version-current'.
 So that `F2 z' will set the correct product's environment before starting
 the gis.  The frame and icon title strings will be modified according to
-`gis-version-frame-title-format' and `gis-version-icon-title-format'."
-  (interactive)
-  (let ((stream (car (magik-version-select-internal))))
+`gis-version-frame-title-format' and `gis-version-icon-title-format'.
+SELECTED-STREAM is the selected definition using the menu or the current line."
+  (interactive
+   (list (if (not (magik-version-at-version-definition))
+             (completing-read "Definition: "
+                              (mapcar #'car (magik-versions-list))
+                              nil t))))
+  (let ((stream (or selected-stream
+                    (car (magik-version--select-internal)))))
     (setq-default magik-version-current stream)
     (kill-buffer (current-buffer))
     (magik-version-display-title)
     (run-hooks 'magik-version-select-hook)
     (message "The current installation for this Emacs is now %s." stream)))
 
-(defun magik-version-select-internal ()
+(defun magik-version--select-internal ()
   "Modify `process-environment' and `exec-path' for current version.
 Return (STREAM VERSION SMALLWORLD_GIS)."
+  (let ((definition (magik-version-at-version-definition)))
+    (let ((stream (nth 0 definition))
+          (version (nth 1 definition))
+          (smallworld-gis (nth 2 definition)))
+      (if (not (and magik-version-current
+                    (string-equal stream magik-version-current)))
+          (magik-version-set-environment smallworld-gis
+                                         stream
+                                         version))
+      (list stream version smallworld-gis))))
+
+(defun magik-version-at-version-definition ()
+  "Return version details if the point is at a version definition.
+The return value is a list (STREAM VERSION SMALLWORLD_GIS), or nil if
+no (valid) match is found."
   (if (< (point) magik-version-position)
       (error "No Environment at this point"))
   (if (save-excursion
         (beginning-of-line)
         (search-forward magik-version-invalid-string (line-end-position) t))
       (error "You have selected an (invalid) Environment"))
-  (let (stream
-        version
-        smallworld-gis)
+  (save-excursion
     (beginning-of-line)
-    (if (looking-at magik-version-match)
-        (setq stream (match-string-no-properties 1)
-              version (match-string-no-properties 2)
-              smallworld-gis  (match-string-no-properties 3))
-      (error "No Environment on this line"))
-    (if (not (and magik-version-current
-                  (string-equal stream magik-version-current)))
-        (magik-version-set-environment smallworld-gis
-                                       stream
-                                       version))
-    (list stream version smallworld-gis)))
+    (save-match-data
+      (when (looking-at magik-version-match)
+        (list (match-string-no-properties 1)
+              (match-string-no-properties 2)
+              (match-string-no-properties 3))))))
 
 (defun magik-version-set-environment (smallworld-gis stream version)
   "Modify the process and exec-path environment given stream and smallworld-gis path."
@@ -485,29 +498,35 @@ Used before running a GIS process."
            (insert (format "Gis Environment: %s\n" magik-version-current))))))
 
 (defun magik-versions-list ()
-  "Return list of version definitions."
+  "Return a list of valid version definitions as (STREAM VERSION SMALLWORLD_GIS)."
   (let (list)
     (save-excursion
       (save-match-data
         (goto-char (point-max))
         (while (and (re-search-backward magik-version-match nil t)
                     (> (point) magik-version-position))
-          (push (match-string-no-properties 1) list))))
+          (unless (save-excursion
+                    (beginning-of-line)
+                    (search-forward magik-version-invalid-string (line-end-position) t))
+            (push (list (match-string-no-properties 1)
+                        (match-string-no-properties 2)
+                        (match-string-no-properties 3))
+                  list)))))
     list))
 
 (defun magik-versions-update-menu ()
   "Update the dynamic Versions submenu."
   (interactive)
-  (if (eq major-mode 'magik-version-mode)
-      (let ((versions (magik-versions-list))
-            entries def)
-        (while versions
-          (setq def (car versions)
-                versions (cdr versions)
-                entries (nconc entries (list (vector def (list 'magik-version-select def) t)))))
-        (easy-menu-change (list "Environment")
-                          "Definitions"
-                          (or entries (list "No Versions found"))))))
+  (when (derived-mode-p 'magik-version-mode)
+    (let ((versions (magik-versions-list))
+          entries def)
+      (while versions
+        (setq def (caar versions)
+              versions (cdr versions)
+              entries (nconc entries (list (vector def (list 'magik-version-select def) t)))))
+      (easy-menu-change (list "Environment")
+                        "Definitions"
+                        (or entries (list "No Versions found"))))))
 
 ;;; Package initialisation
 (modify-syntax-entry ?_  "w"  magik-version-mode-syntax-table)

--- a/magik-version.el
+++ b/magik-version.el
@@ -395,7 +395,7 @@ SELECTED-DEFINITION is the definition using the easy-menu or the current line."
     (message "The current installation for this Emacs is now %s." stream)))
 
 (defun magik-version--set-environment (definition)
-  "Modify `process-environment' and `exec-path' for current version."
+  "Set the environment using DEFINITION."
   (let ((stream (nth 0 definition))
         (version (nth 1 definition))
         (smallworld-gis (nth 2 definition)))
@@ -424,7 +424,7 @@ no (valid) match is found."
               (match-string-no-properties 3))))))
 
 (defun magik-version-set-environment (smallworld-gis stream version)
-  "Modify the process and exec-path environment given stream and smallworld-gis path."
+  "Set the environment variables using SMALLWORLD-GIS, STREAM and VERSION."
   (setenv "SMALLWORLD_GIS" smallworld-gis)
   (setenv "SW_STREAM" stream)
   (setenv "SW_VERSION" version))

--- a/magik-version.el
+++ b/magik-version.el
@@ -94,10 +94,6 @@ This provides an alternative interface to a gis_version program."
 (defvar magik-version-sw-path-list nil
   "Stores list of Smallworld directories added to PATH.")
 
-(defvar magik-smallworld-gis nil
-  "Stores the current SMALLWORLD_GIS.")
-(make-variable-buffer-local 'magik-smallworld-gis)
-
 (defvar magik-version-current nil
   "Current gis_version stream.")
 (make-variable-buffer-local 'magik-version-current)


### PR DESCRIPTION
Stop using `SMALLWORLD_GIS`, but send/retrieve the value if needed without changing the running sessions.

Also fix selecting a definition from the easy-menu.