### PR TITLE
Move bracket that blocks alias selection

### DIFF
--- a/magik-aliases.el
+++ b/magik-aliases.el
@@ -370,8 +370,8 @@ Returns nil if FILE can't be expanded."
                        (buffer-substring-no-properties pt (point))))
                 (if (file-exists-p (concat dir "/config/gis_aliases"))
                     (let ((lp-dir (cons lp dir)))
-                      (or (member lp-dir alist) (push lp-dir alist))))))
-        alist)))))
+                      (or (member lp-dir alist) (push lp-dir alist)))))))
+        alist))))
 
 (defun magik-aliases-layered-products-acp-path (file)
   "Read LAYERED_PRODUCTS configuration file.


### PR DESCRIPTION
In #162  a bracket was moved with the removal of a whitespace