### PR TITLE
added safe method

### DIFF
--- a/magik-mode.el
+++ b/magik-mode.el
@@ -1029,6 +1029,11 @@ After quitting this loop, you can use \\[isearch-forward-regexp] and use \\[isea
           (setq next (re-search-forward search-str nil t))))
       (where-is 'isearch-forward-regexp))))
 
+(defun safe-magik-backward-method ()
+  "Put point at beginning of previous method without errors."
+  (interactive)
+  (magik-backward-method t))
+
 (defun magik-backward-method (&optional noerror)
   "Put point at beginning of this method.
 Optional argument NOERROR ..."
@@ -1043,6 +1048,11 @@ Optional argument NOERROR ..."
     (while (not (looking-at "^\\s-*\\(_method\\|_iter\\|_private\\|_abstract\\|_pragma\\)"))
       (forward-line 1))
     t))
+
+(defun safe-magik-forward-method ()
+  "Put point at beginning of next method without errors."
+  (interactive)
+  (magik-backward-method t))
 
 (defun magik-forward-method (&optional noerror)
   "Put point at beginning of the next method.
@@ -2187,11 +2197,11 @@ Prevents expansion inside strings and comments."
   (define-key magik-base-mode-map "\\" 'magik-electric-pragma-backslash)
 
   (define-key magik-base-mode-map "\C-\M-h" 'magik-mark-method) ;standard key mapping
-  (define-key magik-base-mode-map [M-up] 'magik-backward-method)
-  (define-key magik-base-mode-map [M-down] 'magik-forward-method)
+  (define-key magik-base-mode-map [M-up] 'safe-magik-backward-method)
+  (define-key magik-base-mode-map [M-down] 'safe-magik-forward-method)
 
-  (define-key magik-base-mode-map (kbd "<f2> <up>") 'magik-backward-method)
-  (define-key magik-base-mode-map (kbd "<f2> <down>") 'magik-forward-method)
+  (define-key magik-base-mode-map (kbd "<f2> <up>") 'safe-magik-backward-method)
+  (define-key magik-base-mode-map (kbd "<f2> <down>") 'safe-magik-forward-method)
   (define-key magik-base-mode-map (kbd "<f2> $") 'magik-transmit-$-chunk)
   (define-key magik-base-mode-map (kbd "<f2> D") 'magik-file-sw-method-docs)
   (define-key magik-base-mode-map (kbd "<f2> d") 'magik-single-sw-method-docs)

--- a/magik-mode.el
+++ b/magik-mode.el
@@ -1052,7 +1052,7 @@ Optional argument NOERROR ..."
 (defun safe-magik-forward-method ()
   "Put point at beginning of next method without errors."
   (interactive)
-  (magik-backward-method t))
+  (magik-forward-method t))
 
 (defun magik-forward-method (&optional noerror)
   "Put point at beginning of the next method.

--- a/magik-mode.el
+++ b/magik-mode.el
@@ -1029,7 +1029,7 @@ After quitting this loop, you can use \\[isearch-forward-regexp] and use \\[isea
           (setq next (re-search-forward search-str nil t))))
       (where-is 'isearch-forward-regexp))))
 
-(defun safe-magik-backward-method ()
+(defun magik-safe-backward-method ()
   "Put point at beginning of previous method without errors."
   (interactive)
   (magik-backward-method t))
@@ -1049,7 +1049,7 @@ Optional argument NOERROR ..."
       (forward-line 1))
     t))
 
-(defun safe-magik-forward-method ()
+(defun magik-safe-forward-method ()
   "Put point at beginning of next method without errors."
   (interactive)
   (magik-forward-method t))
@@ -2197,11 +2197,11 @@ Prevents expansion inside strings and comments."
   (define-key magik-base-mode-map "\\" 'magik-electric-pragma-backslash)
 
   (define-key magik-base-mode-map "\C-\M-h" 'magik-mark-method) ;standard key mapping
-  (define-key magik-base-mode-map [M-up] 'safe-magik-backward-method)
-  (define-key magik-base-mode-map [M-down] 'safe-magik-forward-method)
+  (define-key magik-base-mode-map [M-up] 'magik-safe-backward-method)
+  (define-key magik-base-mode-map [M-down] 'magik-safe-forward-method)
 
-  (define-key magik-base-mode-map (kbd "<f2> <up>") 'safe-magik-backward-method)
-  (define-key magik-base-mode-map (kbd "<f2> <down>") 'safe-magik-forward-method)
+  (define-key magik-base-mode-map (kbd "<f2> <up>") 'magik-safe-backward-method)
+  (define-key magik-base-mode-map (kbd "<f2> <down>") 'magik-safe-forward-method)
   (define-key magik-base-mode-map (kbd "<f2> $") 'magik-transmit-$-chunk)
   (define-key magik-base-mode-map (kbd "<f2> D") 'magik-file-sw-method-docs)
   (define-key magik-base-mode-map (kbd "<f2> d") 'magik-single-sw-method-docs)


### PR DESCRIPTION
The keybindings 
- <f2> - up
- <f2> - down
- M - up
- M - down
gave errors when at the end or start of file like such:
![image](https://github.com/user-attachments/assets/7edc45c3-78f6-4f82-b21f-6a2ec4edb700)
This makes small wrappers, that set the no error parameter to true