### PR TITLE
[magik-aliases] Insert current time when starting

### DIFF
--- a/magik-aliases.el
+++ b/magik-aliases.el
@@ -301,6 +301,7 @@ With a prefix arg, ask user for current directory to use."
       (set-buffer buf)
       (magik-session-mode)
 
+      (insert (current-time-string) "\n")
       (insert "Command: " program " ")
       (mapc (function (lambda (s) (insert s " "))) args)
       (setq default-directory dir


### PR DESCRIPTION
When restarting a session, the time is shown as well, so why not when starting it the first time?