### PR TITLE
Simplify completions in module, product and trn mode.

### DIFF
--- a/magik-mode.el
+++ b/magik-mode.el
@@ -2051,7 +2051,7 @@ Translate it and the closing bracket into the new \"{...}\" notation."
   "Expand yasnippet if possible, otherwise insert a space.
 Prevents expansion inside strings and comments."
   (interactive)
-  (if (or (magik--in-string-or-comment-p)
+  (when (or (magik--in-string-or-comment-p)
           (not (yas-expand)))
       (self-insert-command 1)))
 

--- a/magik-mode.el
+++ b/magik-mode.el
@@ -2048,7 +2048,7 @@ Translate it and the closing bracket into the new \"{...}\" notation."
   (syntax-ppss-context (syntax-ppss)))
 
 (defun magik-yas-maybe-expand ()
-  "Expand `yasnippet` if possible, otherwise insert a space.
+  "Expand yasnippet if possible, otherwise insert a space.
 Prevents expansion inside strings and comments."
   (interactive)
   (if (or (magik--in-string-or-comment-p)

--- a/magik-mode.el
+++ b/magik-mode.el
@@ -2052,8 +2052,8 @@ Translate it and the closing bracket into the new \"{...}\" notation."
 Prevents expansion inside strings and comments."
   (interactive)
   (when (or (magik--in-string-or-comment-p)
-          (not (yas-expand)))
-      (self-insert-command 1)))
+            (not (yas-expand)))
+    (self-insert-command 1)))
 
 ;;; Package initialisation
 (define-abbrev-table 'magik-base-mode-abbrev-table

--- a/magik-module.el
+++ b/magik-module.el
@@ -101,7 +101,7 @@ See `imenu-generic-expression'.")
   (customize-group 'magik-module))
 
 (defun magik-module-yas-maybe-expand ()
-  "Expand `yasnippet` if possible, otherwise insert a space.
+  "Expand yasnippet if possible, otherwise insert a space.
 Prevents expansion inside indented areas."
   (interactive)
   (if (or (= 1 (point))

--- a/magik-module.el
+++ b/magik-module.el
@@ -104,7 +104,7 @@ See `imenu-generic-expression'.")
   "Expand yasnippet if possible, otherwise insert a space.
 Prevents expansion inside indented areas."
   (interactive)
-  (if (or (= 1 (point))
+  (when (or (= 1 (point))
           (not (member
                 (get-text-property (- (point) 1) 'face)
                 '(magik-module-keyword-face magik-module-name-face)))

--- a/magik-module.el
+++ b/magik-module.el
@@ -105,11 +105,11 @@ See `imenu-generic-expression'.")
 Prevents expansion inside indented areas."
   (interactive)
   (when (or (= 1 (point))
-          (not (member
-                (get-text-property (- (point) 1) 'face)
-                '(magik-module-keyword-face magik-module-name-face)))
-          (not (yas-expand)))
-      (self-insert-command 1)))
+            (not (member
+                  (get-text-property (- (point) 1) 'face)
+                  '(magik-module-keyword-face magik-module-name-face)))
+            (not (yas-expand)))
+    (self-insert-command 1)))
 
 
 ;;;###autoload

--- a/magik-module.el
+++ b/magik-module.el
@@ -26,6 +26,7 @@
   (require 'magik-session))
 
 (require 'compat)
+(require 'yasnippet)
 
 (defgroup magik-module nil
   "Customise Magik module.def files group."
@@ -68,6 +69,18 @@ See `imenu-generic-expression'.")
   "Open Customization buffer for Module Mode."
   (interactive)
   (customize-group 'magik-module))
+
+(defun magik-module-yas-maybe-expand ()
+  "Expand `yasnippet` if possible, otherwise insert a space.
+Prevents expansion inside indented areas."
+  (interactive)
+  (if (or (= 1 (point))
+          (not (member
+                (get-text-property (- (point) 1) 'face)
+                '(magik-module-keyword-face magik-module-name-face)))
+          (not (yas-expand)))
+      (self-insert-command 1)))
+
 
 ;;;###autoload
 (define-derived-mode magik-module-mode nil "Module"
@@ -292,7 +305,7 @@ Called by `magik-session-drag-n-drop-load' when a Module FILENAME is dropped."
   (fset 'magik-module-f2-map   magik-module-f2-map)
 
   (define-key magik-module-mode-map [f2]    'magik-module-f2-map)
-  (define-key magik-module-mode-map " "     'magik-yas-maybe-expand)
+  (define-key magik-module-mode-map " "     'magik-module-yas-maybe-expand)
 
   (define-key magik-module-f2-map   "b"     'magik-module-transmit-buffer)
   (define-key magik-module-f2-map   "c"     'magik-module-compile-messages)

--- a/magik-module.el
+++ b/magik-module.el
@@ -292,6 +292,7 @@ Called by `magik-session-drag-n-drop-load' when a Module FILENAME is dropped."
   (fset 'magik-module-f2-map   magik-module-f2-map)
 
   (define-key magik-module-mode-map [f2]    'magik-module-f2-map)
+  (define-key magik-module-mode-map " "     'magik-yas-maybe-expand)
 
   (define-key magik-module-f2-map   "b"     'magik-module-transmit-buffer)
   (define-key magik-module-f2-map   "c"     'magik-module-compile-messages)

--- a/magik-product.el
+++ b/magik-product.el
@@ -159,6 +159,7 @@ Called by `magik-session-drag-n-drop-load' when a Product FILENAME is dropped."
   (fset 'magik-product-f2-map   magik-product-f2-map)
 
   (define-key magik-product-mode-map [f2]    'magik-product-f2-map)
+  (define-key magik-product-mode-map " "     'magik-yas-maybe-expand)
 
   (define-key magik-product-f2-map    "b"    'magik-product-transmit-buffer)
   (define-key magik-product-f2-map    "r"    'magik-product-reinitialise))

--- a/magik-product.el
+++ b/magik-product.el
@@ -83,7 +83,7 @@ See `imenu-generic-expression'.")
   (customize-group 'magik-product))
 
 (defun magik-product-yas-maybe-expand ()
-  "Expand `yasnippet` if possible, otherwise insert a space.
+  "Expand yasnippet if possible, otherwise insert a space.
 Prevents expansion inside indented areas."
   (interactive)
   (if (or (= 1 (point))

--- a/magik-product.el
+++ b/magik-product.el
@@ -25,6 +25,8 @@
   (require 'magik-utils)
   (require 'magik-session))
 
+(require 'yasnippet)
+
 (defgroup magik-product nil
   "Customise Magik product.def files group."
   :group 'magik
@@ -56,6 +58,17 @@ See `imenu-generic-expression'.")
   "Open Customization buffer for Product Mode."
   (interactive)
   (customize-group 'magik-product))
+
+(defun magik-product-yas-maybe-expand ()
+  "Expand `yasnippet` if possible, otherwise insert a space.
+Prevents expansion inside indented areas."
+  (interactive)
+  (if (or (= 1 (point))
+          (not (member
+                (get-text-property (- (point) 1) 'face)
+                '(magik-product-keyword-face magik-product-name-face magik-product-type-face)))
+          (not (yas-expand)))
+      (self-insert-command 1)))
 
 ;;;###autoload
 (define-derived-mode magik-product-mode nil "Product"
@@ -159,7 +172,7 @@ Called by `magik-session-drag-n-drop-load' when a Product FILENAME is dropped."
   (fset 'magik-product-f2-map   magik-product-f2-map)
 
   (define-key magik-product-mode-map [f2]    'magik-product-f2-map)
-  (define-key magik-product-mode-map " "     'magik-yas-maybe-expand)
+  (define-key magik-product-mode-map " "     'magik-product-yas-maybe-expand)
 
   (define-key magik-product-f2-map    "b"    'magik-product-transmit-buffer)
   (define-key magik-product-f2-map    "r"    'magik-product-reinitialise))

--- a/magik-product.el
+++ b/magik-product.el
@@ -87,11 +87,11 @@ See `imenu-generic-expression'.")
 Prevents expansion inside indented areas."
   (interactive)
   (when (or (= 1 (point))
-          (not (member
-                (get-text-property (- (point) 1) 'face)
-                '(magik-product-keyword-face magik-product-name-face magik-product-type-face)))
-          (not (yas-expand)))
-      (self-insert-command 1)))
+            (not (member
+                  (get-text-property (- (point) 1) 'face)
+                  '(magik-product-keyword-face magik-product-name-face magik-product-type-face)))
+            (not (yas-expand)))
+    (self-insert-command 1)))
 
 ;;;###autoload
 (define-derived-mode magik-product-mode nil "Product"

--- a/magik-product.el
+++ b/magik-product.el
@@ -86,7 +86,7 @@ See `imenu-generic-expression'.")
   "Expand yasnippet if possible, otherwise insert a space.
 Prevents expansion inside indented areas."
   (interactive)
-  (if (or (= 1 (point))
+  (when (or (= 1 (point))
           (not (member
                 (get-text-property (- (point) 1) 'face)
                 '(magik-product-keyword-face magik-product-name-face magik-product-type-face)))

--- a/magik-trn.el
+++ b/magik-trn.el
@@ -82,6 +82,7 @@ the variable `magik-session-buffer'."
 
 ;; ------------------------ magik trn mode -------------------------
 (define-key magik-trn-mode-map (kbd "<f2> b") 'magik-trn-transmit-buffer)
+(define-key magik-trn-mode-map " "            'magik-yas-maybe-expand)
 
 (provide 'magik-trn)
 ;;; magik-trn.el ends here


### PR DESCRIPTION
For trn mode:
- just use the basic yas-magik-expand

for product and module mode,
check whether the leading character has a keyword or a name-face font. 
if it does we allow completion with <space>

I checked that all snippets work as intended.
When writing e.g. a description nothing is being completed, which is desired