### PR TITLE
Fix for restarting a session after the previous one was killed

### DIFF
--- a/magik-session.el
+++ b/magik-session.el
@@ -699,14 +699,17 @@ there is not, prompt for a command to run, and then run it."
         (alias-buffer "*temp gis alias buffer*")
         (keepgoing t)
         (magik-session-start-process-pre-hook magik-session-start-process-pre-hook)
-        (buffer (magik-utils-get-buffer-mode (cond (buffer buffer)
-                                                   ((derived-mode-p 'magik-session-mode) (buffer-name))
-                                                   (t nil))
-                                             'magik-session-mode
-                                             "Enter Magik Session buffer:"
-                                             (or magik-session-buffer magik-session-buffer-default-name)
-                                             'magik-session-buffer-alist-prefix-function
-                                             (generate-new-buffer-name magik-session-buffer-default-name)))
+        (buffer (or
+                 (magik-utils-get-buffer-mode (cond (buffer buffer)
+                                                    ((derived-mode-p 'magik-session-mode) (buffer-name))
+                                                    (t nil))
+                                              'magik-session-mode
+                                              "Enter Magik Session buffer:"
+                                              (or magik-session-buffer magik-session-buffer-default-name)
+                                              'magik-session-buffer-alist-prefix-function
+                                              (generate-new-buffer-name magik-session-buffer-default-name)
+                                              t)
+                 (generate-new-buffer-name (or magik-session-buffer magik-session-buffer-default-name))))
         (rev-1920-regexp " +\\[rev\\(19\\|20\\)\\] +")
         (alias-subst-regexp "\\\\!\\(\\\\\\)?\\*"))
     (if (and (get-buffer-process buffer)

--- a/magik-session.el
+++ b/magik-session.el
@@ -780,6 +780,9 @@ there is not, prompt for a command to run, and then run it."
                                (file-name-as-directory
                                 (substitute-in-file-name dir))))
       (compat-call setq-local
+                   magik-smallworld-gis (or magik-smallworld-gis
+                                            (when (boundp 'magik-smallworld-gis-current)
+                                              (symbol-value 'magik-smallworld-gis-current)))
                    magik-session-current-command (copy-sequence magik-session-command)
                    magik-session-command-history (cons magik-session-current-command
                                                        (delete magik-session-current-command magik-session-command-history)))


### PR DESCRIPTION
Starting a new session (using F2-z) only worked if you had the previous session buffer active.

If you did not have the previous buffer active or if you killed the buffer completely, it could not start.

Added `t` as predicate for `magik-utils-get-buffer-mode`, because otherwise the predicate would be to only take buffers into account that had an active process.

Added `(generate-new-buffer-name (or magik-session-buffer magik-session-buffer-default-name))` in case of the previous Magik Session buffer was killed completely, but F2-z still knew the command. This would then create a new buffer with the old command.