### PR TITLE
Refactor and always show same startup message

### DIFF
--- a/magik-aliases.el
+++ b/magik-aliases.el
@@ -319,12 +319,8 @@ With a prefix arg, ask user for current directory to use."
       (kill-buffer (current-buffer))
       (set-buffer buf)
       (magik-session-mode)
-      (setq magik-smallworld-gis smallworld-gis)
-
-      (insert (current-time-string) "\n")
-      (insert "Command: " program " ")
-      (mapc (function (lambda (s) (insert s " "))) args)
-      (setq default-directory dir
+      (setq magik-smallworld-gis smallworld-gis
+            default-directory dir
             args (append (list program) args))
       (compat-call setq-local
                    magik-session-current-command (mapconcat 'identity args " "))
@@ -332,7 +328,8 @@ With a prefix arg, ask user for current directory to use."
            (boundp 'magik-version-current)
            (set 'magik-version-current version))
 
-      (insert (format "\nCwd is: %s\n\n" default-directory))
+      (insert (format "Startup time: %s\nCommand: [%s] %s\n" (current-time-string) dir magik-session-current-command))
+
       (magik-session-start-process args))
     (if (magik-aliases-switch-to-buffer alias)
         (display-buffer buf))))

--- a/magik-session.el
+++ b/magik-session.el
@@ -772,7 +772,6 @@ there is not, prompt for a command to run, and then run it."
       (unless (derived-mode-p 'magik-session-mode)
         (magik-session-mode))
       (goto-char (point-max))
-      (insert "\n" (current-time-string) "\n")
       (setq default-directory (expand-file-name
                                (file-name-as-directory
                                 (substitute-in-file-name dir))))
@@ -784,9 +783,9 @@ there is not, prompt for a command to run, and then run it."
                                                         (delete magik-session-current-command magik-session-command-history)))
       (or (file-directory-p default-directory)
           (error "Directory does not exist: %s" default-directory))
-      (add-hook 'magik-session-start-process-pre-hook
-                (function (lambda () (insert magik-session-command ?\n ?\n)))
-                t)
+
+      (insert (format "Startup time: %s\nCommand: %s\n" (current-time-string) magik-session-command))
+
       (magik-session-start-process (magik-session-parse-gis-command (concat cmd " " args))))))
 
 (defun magik-session-new-buffer ()


### PR DESCRIPTION
Refactored to do a single `insert`

Format:
```shell
Startup time: Thu Jun 26 08:41:22 2025
Command: [path/to/config/] path/to/runalias.exe -a path/to/gis_aliases session_name
Gis Environment: environment_name
```