### PR TITLE
[magik-mode] fix for magik-regexp

### DIFF
--- a/magik-mode.el
+++ b/magik-mode.el
@@ -29,12 +29,12 @@
   (defvar msb-menu-cond)
   (require 'magik-indent)
   (require 'magik-electric)
-  (require 'magik-pragma)
-  (require 'magik-doc-gen))
+  (require 'magik-pragma))
 
 (require 'compat)
 (require 'imenu)
 (require 'yasnippet)
+(require 'magik-doc-gen)
 (require 'magik-template)
 
 (defgroup magik nil


### PR DESCRIPTION
Fix magik-regexp not known in magik-mode (after e32caf604cbffc6addae11ab533a40f3175b626b)