### PR TITLE
[magik-lint] Correctly parse `end_line/end_column` and `symbol`

### DIFF
--- a/magik-lint.el
+++ b/magik-lint.el
@@ -70,13 +70,12 @@ See URL `https://github.com/StevenLooman/sonar-magik/tree/master/magik-lint'."
             (eval flycheck-magik-lint-args)
             (config-file "--rcfile" flycheck-magik-lintrc)
             "--max-infractions" (eval (number-to-string flycheck-checker-error-threshold))
-            "--msg-template" "\"${path}:${line}:${column}: (${category}) ${msg} (${symbol})\""
+            "--msg-template" "\"${path}:${line}:${column}:${end_line}:${end_column}: (${category}) [${symbol}] ${msg}\""
             "--column-offset" "+1"
             source)
   :error-patterns
-  ((error line-start (file-name) ":" line ":" column ": (Critical) " (message) line-end)
-   (error line-start (file-name) ":" line ":" column ": (Major) " (message) line-end)
-   (warning line-start (file-name) ":" line ":" column ": (Minor) " (message) line-end))
+  ((error line-start (file-name) ":" line ":" column ":" end-line ":" end-column ": " (or "(Critical)" "(Major)") " [" (id (one-or-more (not (any "]")))) "] " (message) line-end)
+   (warning line-start (file-name) ":" line ":" column ":" end-line ":" end-column ": (Minor) [" (id (one-or-more (not (any "]")))) "] " (message) line-end))
   :modes (magik-mode magik-ts-mode))
 
 (when (and (eq system-type 'windows-nt)


### PR DESCRIPTION
Issue:
<img width="1528" height="370" alt="image" src="https://github.com/user-attachments/assets/d5c6d09e-fab4-49fb-a2d6-f8f76eee7fcd" />
<img width="1704" height="348" alt="image" src="https://github.com/user-attachments/assets/755292e0-ee44-45c1-b433-b6a76df690e2" />

It only marked the start of the issue and not the complete range.

This PR also fixes the empty ID column:
<img width="906" height="47" alt="image" src="https://github.com/user-attachments/assets/6cd73983-addb-4992-b387-733bbb7d8cb6" />
