### PR TITLE
[magik-loadlist] Fix font-lock keyword for loadlist file

### DIFF
--- a/magik-loadlist.el
+++ b/magik-loadlist.el
@@ -50,7 +50,7 @@ Initial ^ and final $ is automatically added in `loadlist-ignore'."
 (defcustom magik-loadlist-font-lock-keywords
   (list
    '("^.+\\([\\/]\\)" 0 'magik-loadlist-folder-face)
-   '("^.+"            0 'magik-loadlist-file-face))
+   '("^\\([^#]+\\)" 1 'magik-loadlist-file-face))
   "Default fontification of load_list.txt files."
   :group 'magik-loadlist
   :type 'sexp)


### PR DESCRIPTION
Before:

<img width="118" height="26" alt="image" src="https://github.com/user-attachments/assets/69368b70-1276-4461-8d33-2a929091e352" />

After:

<img width="127" height="26" alt="image" src="https://github.com/user-attachments/assets/5f10d325-2a89-4852-97ec-1d1be363e5ec" />

