### PR TITLE
Add `\\>` to fix regexp for font-locking names with keywords

### DIFF
--- a/magik-module.el
+++ b/magik-module.el
@@ -85,12 +85,12 @@ See `imenu-generic-expression'.")
 ;; Font-lock configuration
 (defcustom magik-module-font-lock-keywords
   (list
-   (list (concat "^\\<\\(" (mapconcat 'identity magik-module-keywords "\\|") "\\)") 0 ''magik-module-keyword-face t)
    '("^\\(\\sw+\\)\\s-*$"
      (1 'magik-module-name-face))
    '("^\\(\\sw+\\)\\s-+\\([0-9]+\\(?:\\s-*[0-9]+\\)?\\)"
      (1 'magik-module-name-face)
-     (2 'magik-number-face)))
+     (2 'magik-number-face))
+   (list (concat "^\\<\\(" (mapconcat 'identity magik-module-keywords "\\|") "\\)\\>") 0 ''magik-module-keyword-face t))
   "Default fontification of module.def files."
   :group 'magik-module
   :type 'sexp)

--- a/magik-product.el
+++ b/magik-product.el
@@ -72,7 +72,7 @@ See `imenu-generic-expression'.")
      (1 'magik-product-keyword-face)
      (2 'magik-number-face)
      (3 'magik-comment-face))
-   (list (concat "^\\<\\(" (mapconcat 'identity magik-product-keywords "\\|") "\\)") 0 ''magik-product-keyword-face t))
+   (list (concat "^\\<\\(" (mapconcat 'identity magik-product-keywords "\\|") "\\)\\>") 0 ''magik-product-keyword-face t))
   "Default fontification of product.def files."
   :group 'magik-product
   :type 'sexp)


### PR DESCRIPTION
Before:

<img width="163" height="68" alt="image" src="https://github.com/user-attachments/assets/809f81ff-23d9-4d7c-9e77-bd5c591ffd6b" />

After moving `list ...` to the end, just like in product-mode:

<img width="163" height="68" alt="image" src="https://github.com/user-attachments/assets/30d93645-738a-4309-80b3-1d01f987aea3" />

After all fixes:

<img width="163" height="68" alt="image" src="https://github.com/user-attachments/assets/84c72cae-3785-45ed-b560-bd20b7d81cc4" />

Same fix was applied to the product-mode.