### PR TITLE
[magik-product] Fix regex for version matching

### DIFF
--- a/magik-product.el
+++ b/magik-product.el
@@ -68,10 +68,9 @@ See `imenu-generic-expression'.")
    '("^\\(\\sw+\\)\\s-*\\(config_product\\|customisation_product\\|layered_product\\)"
      (1 'magik-product-name-face)
      (2 'magik-product-type-face))
-   '("^\\(version\\)\\s-*\\([0-9]+\\(?:\\.[0-9]+\\)\\{1,3\\}\\(?:-[0-9]+\\)?\\)\\(.*\\)"
+   '("^\\(version\\)\\s-\\(.*\\)"
      (1 'magik-product-keyword-face)
-     (2 'magik-number-face)
-     (3 'magik-comment-face))
+     (2 'magik-number-face))
    (list (concat "^\\<\\(" (mapconcat 'identity magik-product-keywords "\\|") "\\)") 0 ''magik-product-keyword-face t))
   "Default fontification of product.def files."
   :group 'magik-product

--- a/magik-product.el
+++ b/magik-product.el
@@ -68,7 +68,7 @@ See `imenu-generic-expression'.")
    '("^\\(\\sw+\\)\\s-*\\(config_product\\|customisation_product\\|layered_product\\)"
      (1 'magik-product-name-face)
      (2 'magik-product-type-face))
-   '("^\\(version\\)\\s-*\\([0-9]+\\(?:\\.[0-9]+\\)?\\(?:\\.[0-9]+\\)?\\)\\(.*\\)"
+   '("^\\(version\\)\\s-*\\([0-9]+\\(?:\\.[0-9]+\\)\\{1,3\\}\\(?:-[0-9]+\\)?\\)\\(.*\\)"
      (1 'magik-product-keyword-face)
      (2 'magik-number-face)
      (3 'magik-comment-face))


### PR DESCRIPTION
Make sure it matches `1.2.3.4-10` (which is a valid sw_version)

Before:
<img width="131" height="17" alt="image" src="https://github.com/user-attachments/assets/a9c0aef2-ec7c-41a2-9d9a-820b5c9940b6" />

After:
<img width="136" height="19" alt="image" src="https://github.com/user-attachments/assets/c4af1320-4b44-4681-8769-79c8d71642f0" />
