### PR TITLE
[magik-module] Module name with `test_` was fontlocked as keyword

### DIFF
--- a/Eask
+++ b/Eask
@@ -10,6 +10,8 @@
 (package-file "magik-mode.el")
 (files "*.el" "snippets")
 
+(script "test" "eask test ert test/test-helper.el ./test/*-test.el")
+
 (source "gnu")
 (source "melpa")
 
@@ -17,8 +19,6 @@
 (depends-on "compat")
 (depends-on "flycheck")
 (depends-on "yasnippet")
-
-(script "test" "eask test ert test/test-helper.el ./test/*-test.el")
 
 ;; do not try to compile magik-ts-mode.el if we are below 29.1
 (when (version< emacs-version "29.1")

--- a/magik-module.el
+++ b/magik-module.el
@@ -89,8 +89,7 @@ See `imenu-generic-expression'.")
 ;; Font-lock configuration
 (defcustom magik-module-font-lock-keywords
   (list
-   (list (concat "^\\<\\(" (mapconcat 'identity magik-module-keywords "\\|") "\\)") 0 ''magik-module-keyword-face t)
-   (list (concat "^\\<\\(" (mapconcat 'identity magik-module-installation-keywords "\\|") "\\)") 0 ''magik-module-keyword-face t)
+   (list (concat "^\\<\\(" (mapconcat 'identity magik-module-installation-keywords "\\|") "\\)\\>") 0 ''magik-module-keyword-face t)
    '("^\\([[:word:]!]+\\)\\s-*$"
      (1 'magik-module-name-face))
    '("^\\([[:word:]!]+\\)\\s-+\\([0-9]+\\(?:\\s-*[0-9]+\\)?\\)"

--- a/test/magik-module-test.el
+++ b/test/magik-module-test.el
@@ -1,0 +1,91 @@
+;;; magik-module-test.el --- Tests for magik-module.el  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; ERT tests for font-lock highlighting in `magik-module-mode'.
+
+;;; Code:
+
+(require 'test-helper)
+(require 'magik-module)
+
+(defun magik-module-test--face-at (content target)
+  "Return face at start of TARGET in a fontified magik-module-mode buffer with CONTENT."
+  (with-temp-buffer
+    (magik-module-mode)
+    (insert content)
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (search-forward target)
+    (get-text-property (match-beginning 0) 'face)))
+
+(defun magik-module-test--face-p (pos face)
+  "Return non-nil if FACE is among the face properties at POS."
+  (let ((f (get-text-property pos 'face)))
+    (if (listp f) (memq face f) (eq face f))))
+
+;;; Module name face
+
+(ert-deftest magik-module-font-lock--plain-name-has-name-face ()
+  "A module name followed by a version number gets name face."
+  (should (eq (magik-module-test--face-at "pieces_tests\t1\n" "pieces_tests")
+              'magik-module-name-face)))
+
+(ert-deftest magik-module-font-lock--name-prefixed-with-keyword-has-name-face ()
+  "Module name `test_core' gets name face, not partial keyword face.
+Regression: the `test' keyword rule without a word-boundary anchor previously
+matched `test' as a prefix of `test_core', overriding the name face for those
+four characters."
+  (should (eq (magik-module-test--face-at "test_core\t1\n" "test_core")
+              'magik-module-name-face)))
+
+(ert-deftest magik-module-font-lock--no-char-in-test_core-name-has-keyword-face ()
+  "No character inside the `test_core' module name gets keyword face."
+  (with-temp-buffer
+    (magik-module-mode)
+    (insert "test_core\t1\n")
+    (font-lock-ensure)
+    (should-not
+     (let ((found nil))
+       (dotimes (i (length "test_core") found)
+         (when (magik-module-test--face-p (+ (point-min) i)
+                                          'magik-module-keyword-face)
+           (setq found t)))))))
+
+;;; Keyword face
+
+(ert-deftest magik-module-font-lock--test-keyword-has-keyword-face ()
+  "`test' on its own line gets keyword face."
+  (should (eq (magik-module-test--face-at "test\n\tname\tfoo\nend\n" "test")
+              'magik-module-keyword-face)))
+
+(ert-deftest magik-module-font-lock--description-has-keyword-face ()
+  "`description' at the start of a line gets keyword face."
+  (should (eq (magik-module-test--face-at "description\n\tsome text\nend\n"
+                                          "description")
+              'magik-module-keyword-face)))
+
+(ert-deftest magik-module-font-lock--requires-has-keyword-face ()
+  "`requires' at the start of a line gets keyword face."
+  (should (eq (magik-module-test--face-at "requires\n\tboard_manager\nend\n"
+                                          "requires")
+              'magik-module-keyword-face)))
+
+(ert-deftest magik-module-font-lock--end-has-keyword-face ()
+  "`end' closing a block gets keyword face."
+  (should (eq (magik-module-test--face-at "description\n\tsome text\nend\n" "end")
+              'magik-module-keyword-face)))
+
+(ert-deftest magik-module-font-lock--hidden-has-keyword-face ()
+  (should (eq (magik-module-test--face-at "hidden\n" "hidden")
+              'magik-module-keyword-face)))
+
+;;; Version number face
+
+(ert-deftest magik-module-font-lock--version-number-has-number-face ()
+  "The version number after a module name gets number face."
+  (should (eq (magik-module-test--face-at "my_module\t1\n" "1")
+              'magik-number-face)))
+
+(provide 'magik-module-test)
+;;; magik-module-test.el ends here


### PR DESCRIPTION
Before:

<img width="131" height="23" alt="image" src="https://github.com/user-attachments/assets/64596f21-9400-4fd0-a8a7-bb4ced45050b" />

After:

<img width="141" height="15" alt="image" src="https://github.com/user-attachments/assets/9b063d67-6a4e-45d2-b961-b522abc879fc" />
