### PR TITLE
Fix error when using `magik-transmit-region` / `F2-r`

### DIFF
--- a/magik-completion.el
+++ b/magik-completion.el
@@ -926,7 +926,7 @@ Returns (BEG . END) of the condition name being typed, or nil."
 (defun magik-completion-invalidate-cache (&rest _args)
   "Invalidate all CB completion caches.
 Intended to be called after transmitting code to the session."
-  (interactive)
+  (interactive "r")
   (setq magik-completion--class-cache nil
         magik-completion--class-cache-loaded nil
         magik-completion--global-cache nil


### PR DESCRIPTION
```elisp
apply: Wrong number of arguments: #[(beg end) "    \" b      )  % " [beg end magik-transmit-string buffer-substring-no-properties beginning-of-line magik-package-line #[(f) "      
\0 $ " [f magik-function "load_file" unset buffer-file-name] 5] #[(f) "    $ " [f magik-function "system.unlink" false true] 5]] 6 ("c:/Users/506623/AppData/Roaming/.emacs.d/elpa/magik-mode/magik-mode.elc" . 45722) "r"], 0
```