### PR TITLE
Add `#%text_encoding=` font-lock across magik/msg/trn modes

### DIFF
--- a/magik-mode.el
+++ b/magik-mode.el
@@ -310,6 +310,11 @@ concrete implementations."
   "Font Lock mode face used to display comments."
   :group 'magik-faces)
 
+(defface magik-text-encoding-face
+  '((t (:inherit magik-comment-face :weight bold)))
+  "Font Lock mode face used to display the text encoding tag."
+  :group 'magik-faces)
+
 (defface magik-constant-face
   '((t (:inherit font-lock-constant-face)))
   "Font Lock mode face used to display constants."
@@ -535,7 +540,8 @@ constants which use the `font-lock-constant-face' face."
                  (mapconcat 'identity magik-warnings "\\|")
                  "\\)")
          0 ''magik-warning-face t)
-   '("^\\s-*##.*$" 0 'magik-doc-face t))
+   '("^\\s-*##.*$" 0 'magik-doc-face t)
+   '("^#%\\s-*text_encoding.*$" 0 'magik-text-encoding-face t))
   "Font lock setting for 2nd level of Magik fontification.
 Fontifies certain Magik language features like symbols, dynamics but does
 NOT fontify ANY Magik Keywords."

--- a/magik-msg.el
+++ b/magik-msg.el
@@ -65,7 +65,7 @@ See `imenu-generic-expression'.")
   :group 'magik-msg-faces)
 
 (defface magik-msg-text-encoding-face
-  '((t :inherit magik-warning-face))
+  '((t :inherit magik-text-encoding-face))
   "Font Lock mode face used to display the text encoding."
   :group 'magik-msg-faces)
 

--- a/magik-trn.el
+++ b/magik-trn.el
@@ -30,6 +30,44 @@
 (require 'magik-session)
 (require 'magik-utils)
 
+(defgroup magik-trn nil
+  "Customise Magik Translation group."
+  :group 'magik
+  :group 'tools)
+
+(defgroup magik-trn-faces nil
+  "Faces for displaying text in a Magik Translation file."
+  :group 'magik-trn)
+
+(defface magik-trn-comment-face
+  '((t :inherit magik-comment-face))
+  "Font Lock mode face used to display comments."
+  :group 'magik-trn-faces)
+
+(defface magik-trn-type-face
+  '((t :inherit magik-class-face))
+  "Font Lock mode face used to display the translation type."
+  :group 'magik-trn-faces)
+
+(defface magik-trn-text-encoding-face
+  '((t :inherit magik-text-encoding-face))
+  "Font Lock mode face used to display the text encoding."
+  :group 'magik-trn-faces)
+
+(defvar magik-trn-keyword-types
+  '("external_name" "enumerator" "field_value")
+  "List of keywords relating to Magik Translation types to highlight for font-lock.")
+
+;; Font-lock configuration
+(defcustom magik-trn-font-lock-keywords
+  (list
+   (cons (concat "^\\(" (regexp-opt magik-trn-keyword-types t) "\\)\t") ''magik-trn-type-face)
+   '("^#.*$" 0 'magik-trn-comment-face t)
+   '("^#%\\s-*text_encoding.*$" 0 'magik-trn-text-encoding-face t))
+  "Default fontification of Magik Translation files."
+  :group 'magik-trn
+  :type 'sexp)
+
 ;;;###autoload
 (define-derived-mode magik-trn-mode nil "Translation"
   "Major mode for editing Magik Translation files.
@@ -41,7 +79,8 @@
 
   (compat-call setq-local
                require-final-newline t
-               indent-tabs-mode t))
+               indent-tabs-mode t
+               font-lock-defaults '(magik-trn-font-lock-keywords nil t)))
 
 (defvar magik-trn-menu nil
   "Keymap for the Magik Translation buffer menu bar.")

--- a/magik-ts-mode.el
+++ b/magik-ts-mode.el
@@ -41,8 +41,11 @@
 
    :language 'magik
    :feature 'comment
+   :override t
    '((comment) @magik-comment-face
-     (documentation) @magik-doc-face)
+     (documentation) @magik-doc-face
+     ((comment) @magik-text-encoding-face
+      (:match "^#%[ \t]*text_encoding" @magik-text-encoding-face)))
 
    :language 'magik
    :feature 'type

--- a/snippets/magik-mode/text_encoding
+++ b/snippets/magik-mode/text_encoding
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: text_encoding
+# key: text_encoding
+# group: documentation
+# --
+#%text_encoding=${1:utf8}
+$0

--- a/test/magik-mode-test.el
+++ b/test/magik-mode-test.el
@@ -196,5 +196,36 @@
         (should (member "size" all-names))
         (should (member "new()" all-names))))))
 
+;;; magik-text-encoding-face (font-lock)
+
+(ert-deftest magik-text-encoding-face--spaced ()
+  (with-temp-buffer
+    (let ((font-lock-maximum-decoration t))
+      (magik-mode)
+      (insert "#% text_encoding = iso8859_1\n")
+      (insert "_package user\n")
+      (font-lock-ensure)
+      (goto-char (point-min))
+      (should (eq (get-text-property (point) 'face) 'magik-text-encoding-face)))))
+
+(ert-deftest magik-text-encoding-face--no-spaces ()
+  (with-temp-buffer
+    (let ((font-lock-maximum-decoration t))
+      (magik-mode)
+      (insert "#%text_encoding=utf8\n")
+      (insert "_package user\n")
+      (font-lock-ensure)
+      (goto-char (point-min))
+      (should (eq (get-text-property (point) 'face) 'magik-text-encoding-face)))))
+
+(ert-deftest magik-text-encoding-face--not-fontified-without-tag ()
+  (with-temp-buffer
+    (let ((font-lock-maximum-decoration t))
+      (magik-mode)
+      (insert "_package user\n")
+      (font-lock-ensure)
+      (goto-char (point-min))
+      (should-not (eq (get-text-property (point) 'face) 'magik-text-encoding-face)))))
+
 (provide 'magik-mode-test)
 ;;; magik-mode-test.el ends here

--- a/test/magik-msg-test.el
+++ b/test/magik-msg-test.el
@@ -1,0 +1,48 @@
+;;; magik-msg-test.el --- Tests for magik-msg.el  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; ERT tests covering font-lock fontification in `magik-msg.el'.
+
+;;; Code:
+
+(require 'test-helper)
+(require 'magik-msg)
+
+;;; magik-msg-text-encoding-face (font-lock)
+
+(ert-deftest magik-msg-text-encoding-face--spaced ()
+  (with-temp-buffer
+    (magik-msg-mode)
+    (insert "#% text_encoding = iso8859_1\n")
+    (insert ":foo\tBar\n")
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (should (eq (get-text-property (point) 'face) 'magik-msg-text-encoding-face))))
+
+(ert-deftest magik-msg-text-encoding-face--no-spaces ()
+  (with-temp-buffer
+    (magik-msg-mode)
+    (insert "#%text_encoding=utf8\n")
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (should (eq (get-text-property (point) 'face) 'magik-msg-text-encoding-face))))
+
+(ert-deftest magik-msg-text-encoding-face--not-fontified-without-tag ()
+  (with-temp-buffer
+    (magik-msg-mode)
+    (insert ":foo\tBar\n")
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (should-not (eq (get-text-property (point) 'face) 'magik-msg-text-encoding-face))))
+
+;;; face inheritance
+
+(ert-deftest magik-msg-text-encoding-face--inherits-shared-face ()
+  (should (eq (face-attribute 'magik-msg-text-encoding-face :inherit) 'magik-text-encoding-face)))
+
+(ert-deftest magik-msg-comment-face--inherits-shared-face ()
+  (should (eq (face-attribute 'magik-msg-comment-face :inherit) 'magik-comment-face)))
+
+(provide 'magik-msg-test)
+;;; magik-msg-test.el ends here

--- a/test/magik-trn-test.el
+++ b/test/magik-trn-test.el
@@ -1,0 +1,119 @@
+;;; magik-trn-test.el --- Tests for magik-trn.el  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; ERT tests covering font-lock fontification in `magik-trn.el'.
+
+;;; Code:
+
+(require 'test-helper)
+(require 'magik-trn)
+
+;;; auto-mode-alist
+
+(ert-deftest magik-trn--auto-mode-alist ()
+  (should (eq (assoc-default "foo.trn" auto-mode-alist 'string-match) 'magik-trn-mode)))
+
+;;; magik-trn-text-encoding-face (font-lock)
+
+(ert-deftest magik-trn-text-encoding-face--spaced ()
+  (with-temp-buffer
+    (magik-trn-mode)
+    (insert "#% text_encoding = iso8859_1\n")
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (should (eq (get-text-property (point) 'face) 'magik-trn-text-encoding-face))))
+
+(ert-deftest magik-trn-text-encoding-face--no-spaces ()
+  (with-temp-buffer
+    (magik-trn-mode)
+    (insert "#%text_encoding=utf8\n")
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (should (eq (get-text-property (point) 'face) 'magik-trn-text-encoding-face))))
+
+;;; magik-trn-comment-face (font-lock)
+
+(ert-deftest magik-trn-comment-face--generic-comment-line ()
+  (with-temp-buffer
+    (magik-trn-mode)
+    (insert "# (c) 2024 Example Company. All Rights Reserved.\n")
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (should (eq (get-text-property (point) 'face) 'magik-trn-comment-face))))
+
+(ert-deftest magik-trn-comment-face--column-header-comment ()
+  (with-temp-buffer
+    (magik-trn-mode)
+    (insert "# external_name\ttable_name\tunset\ten_gb\tstring\ttranslation\n")
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (should (eq (get-text-property (point) 'face) 'magik-trn-comment-face))))
+
+(ert-deftest magik-trn-comment-face--text-encoding-not-generic-comment ()
+  "The text_encoding line must keep its own face, not the generic comment face."
+  (with-temp-buffer
+    (magik-trn-mode)
+    (insert "#% text_encoding = utf8\n")
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (should-not (eq (get-text-property (point) 'face) 'magik-trn-comment-face))))
+
+;;; magik-trn-type-face (font-lock)
+
+(ert-deftest magik-trn-type-face--external-name ()
+  (with-temp-buffer
+    (magik-trn-mode)
+    (insert "external_name\tfoo\tunset\ten_gb\tFoo\tFoo\n")
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (should (eq (get-text-property (point) 'face) 'magik-trn-type-face))))
+
+(ert-deftest magik-trn-type-face--enumerator ()
+  (with-temp-buffer
+    (magik-trn-mode)
+    (insert "enumerator\tfoo\tunset\ten_gb\tFoo\tFoo\n")
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (should (eq (get-text-property (point) 'face) 'magik-trn-type-face))))
+
+(ert-deftest magik-trn-type-face--field-value ()
+  (with-temp-buffer
+    (magik-trn-mode)
+    (insert "field_value\tfoo\tbar\ten_gb\tFoo\tFoo\n")
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (should (eq (get-text-property (point) 'face) 'magik-trn-type-face))))
+
+(ert-deftest magik-trn-type-face--not-fontified-mid-line ()
+  "The type keyword must only be recognised in the first column."
+  (with-temp-buffer
+    (magik-trn-mode)
+    (insert "foo\texternal_name\tbar\ten_gb\tFoo\tFoo\n")
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (should-not (eq (get-text-property (point) 'face) 'magik-trn-type-face))))
+
+(ert-deftest magik-trn-type-face--key1-not-fontified ()
+  "Only the type column itself should be fontified, not the following field."
+  (with-temp-buffer
+    (magik-trn-mode)
+    (insert "external_name\tfoo\tunset\ten_gb\tFoo\tFoo\n")
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (forward-char (length "external_name\t"))
+    (should-not (eq (get-text-property (point) 'face) 'magik-trn-type-face))))
+
+;;; face inheritance
+
+(ert-deftest magik-trn-comment-face--inherits-shared-face ()
+  (should (eq (face-attribute 'magik-trn-comment-face :inherit) 'magik-comment-face)))
+
+(ert-deftest magik-trn-text-encoding-face--inherits-shared-face ()
+  (should (eq (face-attribute 'magik-trn-text-encoding-face :inherit) 'magik-text-encoding-face)))
+
+(ert-deftest magik-trn-type-face--inherits-shared-face ()
+  (should (eq (face-attribute 'magik-trn-type-face :inherit) 'magik-class-face)))
+
+(provide 'magik-trn-test)
+;;; magik-trn-test.el ends here

--- a/test/magik-ts-mode-test.el
+++ b/test/magik-ts-mode-test.el
@@ -1,0 +1,58 @@
+;;; magik-ts-mode-test.el --- Tests for magik-ts-mode.el  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; ERT tests for magik-ts-mode's tree-sitter font-lock rules.  Entirely
+;; skipped when tree-sitter or the magik grammar is not available (e.g.
+;; Emacs < 29.1, or the grammar not compiled/installed) rather than
+;; erroring, since neither is guaranteed in every environment this test
+;; suite runs in.
+
+;;; Code:
+
+(require 'test-helper)
+
+(defvar magik-ts-mode-test--available
+  (and (fboundp 'treesit-available-p)
+       (treesit-available-p)
+       (ignore-errors (require 'magik-ts-mode nil t))
+       (fboundp 'treesit-ready-p)
+       (treesit-ready-p 'magik))
+  "Non-nil if the magik tree-sitter grammar is available for testing.")
+
+(defun magik-ts-mode-test--skip-unless-available ()
+  "Skip the current test unless the magik tree-sitter grammar is available."
+  (unless magik-ts-mode-test--available
+    (ert-skip "magik tree-sitter grammar is not available")))
+
+(defun magik-ts-mode-test--face-at-point-min (code)
+  "Insert CODE, activate `magik-ts-mode', and return the face at point-min."
+  (with-temp-buffer
+    (insert code)
+    (magik-ts-mode)
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (get-text-property (point) 'face)))
+
+;;; magik-text-encoding-face (font-lock)
+
+(ert-deftest magik-ts-mode--text-encoding-face-spaced ()
+  (magik-ts-mode-test--skip-unless-available)
+  (should (eq (magik-ts-mode-test--face-at-point-min
+               "#% text_encoding = iso8859_1\n_package user\n")
+              'magik-text-encoding-face)))
+
+(ert-deftest magik-ts-mode--text-encoding-face-no-spaces ()
+  (magik-ts-mode-test--skip-unless-available)
+  (should (eq (magik-ts-mode-test--face-at-point-min
+               "#%text_encoding=utf8\n_package user\n")
+              'magik-text-encoding-face)))
+
+(ert-deftest magik-ts-mode--plain-comment-still-uses-comment-face ()
+  (magik-ts-mode-test--skip-unless-available)
+  (should (eq (magik-ts-mode-test--face-at-point-min
+               "# just a regular comment\n_package user\n")
+              'magik-comment-face)))
+
+(provide 'magik-ts-mode-test)
+;;; magik-ts-mode-test.el ends here


### PR DESCRIPTION
Also created more font-lock rules for trn mode and add a YASnippet