### PR TITLE
[magik-completion] Apply better fix for calling invalidate cache

### DIFF
--- a/magik-completion.el
+++ b/magik-completion.el
@@ -975,7 +975,7 @@ Intended to be called after transmitting code to the session."
     (remove-hook 'completion-at-point-functions fn t))
   (dolist (fn magik-completion--transmit-functions)
     (when (fboundp fn)
-      (advice-remove fn #'magik-completion-invalidate-cache))))
+      (advice-remove fn #'magik-completion--invalidate-cache))))
 
 (define-minor-mode magik-completion-mode
   "Toggle Magik `completion-at-point' support in the current buffer."

--- a/magik-completion.el
+++ b/magik-completion.el
@@ -923,10 +923,15 @@ Returns (BEG . END) of the condition name being typed, or nil."
 
 ;;; --- Cache invalidation ---
 
-(defun magik-completion-invalidate-cache (&rest _args)
+(defun magik-completion--invalidate-cache (&rest _args)
   "Invalidate all CB completion caches.
 Intended to be called after transmitting code to the session."
-  (interactive "r")
+  (interactive)
+  (magik-completion--invalidate-cache))
+
+(defun magik-completion--invalidate-cache (&rest _args)
+  "Invalidate all CB completion caches.
+Intended to be called after transmitting code to the session."
   (setq magik-completion--class-cache nil
         magik-completion--class-cache-loaded nil
         magik-completion--global-cache nil
@@ -962,7 +967,7 @@ Intended to be called after transmitting code to the session."
     (add-hook 'completion-at-point-functions fn nil t))
   (dolist (fn magik-completion--transmit-functions)
     (when (fboundp fn)
-      (advice-add fn :after #'magik-completion-invalidate-cache))))
+      (advice-add fn :after #'magik-completion--invalidate-cache))))
 
 (defun magik-completion--disable ()
   "Remove Magik CAPF functions from the current buffer."

--- a/magik-completion.el
+++ b/magik-completion.el
@@ -923,9 +923,9 @@ Returns (BEG . END) of the condition name being typed, or nil."
 
 ;;; --- Cache invalidation ---
 
-(defun magik-completion--invalidate-cache ()
+(defun magik-completion-invalidate-cache ()
   "Invalidate all CB completion caches.
-Intended to be called after transmitting code to the session."
+Can be called after loading code in the session."
   (interactive)
   (magik-completion--invalidate-cache))
 

--- a/magik-completion.el
+++ b/magik-completion.el
@@ -923,7 +923,7 @@ Returns (BEG . END) of the condition name being typed, or nil."
 
 ;;; --- Cache invalidation ---
 
-(defun magik-completion--invalidate-cache (&rest _args)
+(defun magik-completion--invalidate-cache ()
   "Invalidate all CB completion caches.
 Intended to be called after transmitting code to the session."
   (interactive)


### PR DESCRIPTION
Using `advice-add` with an interactive `defun` doesn't work always