### PR TITLE
Fix no-op `save-match-data` in `magik-aliases-next`

### DIFF
--- a/magik-aliases.el
+++ b/magik-aliases.el
@@ -211,12 +211,12 @@ You can customise `magik-aliases-mode' with the `magik-aliases-mode-hook'.
 (defun magik-aliases-next ()
   "Move point to next valid alias listed."
   (interactive)
-  (save-match-data)
-  (if (re-search-forward magik-aliases-definition-regexp nil t)
-      (forward-line)
-    (goto-char (point-min))
-    (when (re-search-forward magik-aliases-definition-regexp nil t)
-      (forward-line))))
+  (save-match-data
+    (if (re-search-forward magik-aliases-definition-regexp nil t)
+        (forward-line)
+      (goto-char (point-min))
+      (when (re-search-forward magik-aliases-definition-regexp nil t)
+        (forward-line)))))
 
 (defun magik-aliases-q ()
   "If buffer is read-only goto next alias, else insert q."

--- a/test/magik-aliases-test.el
+++ b/test/magik-aliases-test.el
@@ -55,6 +55,38 @@
       ;; The blank line is within alias_one's scope (backward search finds it)
       (should (stringp result)))))
 
+;;; magik-aliases-next
+
+(ert-deftest magik-aliases-next--moves-to-next-definition ()
+  (with-temp-buffer
+    (magik-aliases-mode)
+    (insert "alias_one:\n\tCOMMAND=x\nalias_two:\n\tCOMMAND=y\n")
+    (goto-char (point-min))
+    (magik-aliases-next)
+    (should (equal (buffer-substring-no-properties
+                    (line-beginning-position) (line-end-position))
+                   "\tCOMMAND=x"))))
+
+(ert-deftest magik-aliases-next--wraps-around-at-end-of-buffer ()
+  (with-temp-buffer
+    (magik-aliases-mode)
+    (insert "alias_one:\n\tCOMMAND=x\nalias_two:\n\tCOMMAND=y\n")
+    (goto-char (point-max))
+    (magik-aliases-next)
+    (should (equal (buffer-substring-no-properties
+                    (line-beginning-position) (line-end-position))
+                   "\tCOMMAND=x"))))
+
+(ert-deftest magik-aliases-next--preserves-match-data ()
+  "`magik-aliases-next' must not clobber the caller's match data."
+  (with-temp-buffer
+    (magik-aliases-mode)
+    (insert "alias_one:\n\tCOMMAND=x\nalias_two:\n\tCOMMAND=y\n")
+    (goto-char (point-min))
+    (should (string-match "\\(quick\\) brown" "the quick brown fox"))
+    (magik-aliases-next)
+    (should (equal (match-string 1 "the quick brown fox") "quick"))))
+
 ;;; magik-aliases-expand-file
 
 (ert-deftest magik-aliases-expand-file--expands-env-var ()


### PR DESCRIPTION
### Problem

`magik-aliases-next` calls `save-match-data` with no body:

```elisp
(interactive)
(save-match-data)
(if (re-search-forward magik-aliases-definition-regexp nil t)
    ...
```

That form saves the match data and restores it immediately, then returns. The two `re-search-forward` calls that follow are outside it, so the caller's match data is clobbered after all. The parentheses were almost certainly meant to wrap the body.

### Fix

Wrap the body, which is the idiom `magik-version-next` a few lines away in `magik-version.el` already uses.

### Tests

Adds three tests for `magik-aliases-next`, which had none:

- moves to the next definition
- wraps around at the end of the buffer
- preserves the caller's match data

The third fails on `master` and passes with the fix; the other two pass either way and just cover a previously untested command.

```
Ran 203 tests, 200 results as expected, 0 unexpected, 3 skipped
```