### PR TITLE
Let C-S-a select a region in Magik session buffers

### DIFF
--- a/magik-session.el
+++ b/magik-session.el
@@ -920,7 +920,7 @@ Copies the non-degenerate commands into it."
 (defun magik-session-beginning-of-line (&optional n)
   "Move point to beginning of Nth line or just after prompt.
 If command is repeated then place point at beginning of prompt."
-  (interactive "p")
+  (interactive "^p")
   (beginning-of-line n)
   ;;Only move to end of prompt if last-command was this one
   ;;AND a prefix key has not be used (n=1).

--- a/test/magik-session-test.el
+++ b/test/magik-session-test.el
@@ -55,5 +55,58 @@
     (let ((magik-session-buffer-alist nil))
       (should-not (magik-session-buffer-alist-remove)))))
 
+;;; magik-session-beginning-of-line
+
+(ert-deftest magik-session-beginning-of-line--moves-past-the-prompt ()
+  (with-temp-buffer
+    (magik-session-mode)
+    (insert "Magik> print(1)")
+    (let ((last-command nil))
+      (magik-session-beginning-of-line 1))
+    (should (equal (buffer-substring-no-properties (point) (point-max))
+                   "print(1)"))))
+
+(ert-deftest magik-session-beginning-of-line--repeated-goes-to-column-zero ()
+  "Repeating the command moves point right to the beginning of the line."
+  (with-temp-buffer
+    (magik-session-mode)
+    (insert "Magik> print(1)")
+    (let ((last-command 'magik-session-beginning-of-line))
+      (magik-session-beginning-of-line 1))
+    (should (= (point) (line-beginning-position)))))
+
+(ert-deftest magik-session-beginning-of-line--is-shift-select-aware ()
+  "Both preconditions for `shift-select-mode' must hold on C-S-a.
+Emacs only shift-translates C-S-a to C-a while C-S-a is unbound, and the
+command it lands on only extends the region when its interactive spec
+starts with `^'."
+  (with-temp-buffer
+    (magik-session-mode)
+    (should-not (lookup-key magik-session-mode-map (kbd "C-S-a")))
+    (let ((spec (cadr (interactive-form (key-binding (kbd "C-a"))))))
+      (should (stringp spec))
+      (should (string-prefix-p "^" spec)))))
+
+(ert-deftest magik-session-beginning-of-line--shift-selection-selects-command ()
+  "Pressing C-S-a selects back to the prompt, as it does in a shell buffer.
+The buffer has to be displayed, otherwise the key cannot be executed."
+  (let ((buffer (get-buffer-create "*magik-session-test*"))
+        (shift-select-mode t)
+        (transient-mark-mode t))
+    (unwind-protect
+        (save-window-excursion
+          (switch-to-buffer buffer)
+          (magik-session-mode)
+          (erase-buffer)
+          (insert "Magik> print(1)")
+          (goto-char (point-max))
+          (deactivate-mark)
+          (execute-kbd-macro (kbd "C-S-a"))
+          (should (region-active-p))
+          (should (equal (buffer-substring-no-properties
+                          (region-beginning) (region-end))
+                         "print(1)")))
+      (kill-buffer buffer))))
+
 (provide 'magik-session-test)
 ;;; magik-session-test.el ends here


### PR DESCRIPTION
### Problem

Pressing `C-S-a` in a Magik session buffer moves point to the prompt but selects nothing.

`C-S-a` is unbound, so Emacs shift-translates it to `C-a`, and `shift-select-mode` only extends the region when the resolved command's interactive spec starts with `^`. `C-a` is bound to `magik-session-beginning-of-line`, whose spec is `"p"`.

Reproduction, with a fundamental-mode buffer as the control:

```
control: fundamental   C-a=move-beginning-of-line           spec="^p"  region="Magik> print(1)"
magik-session-mode     C-a=magik-session-beginning-of-line  spec="p"   region=NOTHING SELECTED
```

`comint-mode-map` no longer binds `C-a` at all, so a shell buffer gets the global `move-beginning-of-line` and its `"^p"` spec. A session buffer behaving differently from every other comint-like buffer is the surprise here.

### Fix

`(interactive "p")` becomes `(interactive "^p")`. The prompt-aware behaviour is untouched, including the "press again to go right to the beginning" case, which depends on `last-command` rather than the spec.

After the fix the same reproduction selects the command but not the prompt, which is what a shell buffer does:

```
magik-session-mode     C-a=magik-session-beginning-of-line  spec="^p"  region="print(1)"
```

### Tests

Four tests in `test/magik-session-test.el`:

- moves past the prompt
- repeating it goes to column zero
- the invariant behind shift selection: `C-S-a` unbound in the mode map, and `C-a`'s command has a `^` spec
- end-to-end: presses `C-S-a` in a displayed buffer and checks the region

The last two fail on `master`. The first two pass either way and are there to catch a regression in the prompt handling from this change.

```
Ran 204 tests, 201 results as expected, 0 unexpected, 3 skipped
```

### Related

Same defect class as #218. I audited all 14 magik mode maps for it: every motion key bound to a command whose interactive spec lacks `^`, and every printable character shadowing `self-insert-command`. This was the only other real instance.

The class browser's `magik-cb-forward-char`, `-backward-char`, `-beginning-of-line` and `-end-of-line` also lack `^`, but they move a virtual cursor across the two hidden buffers behind the CB mode line rather than point in a buffer, so shift-selection does not apply and `^` would be wrong there. The bare-letter bindings in `magik-version-mode-map`, `magik-pragma-topic-select-mode-map` and `magik-cb-mode-map` are all in read-only or scratch selection buffers, and `magik-yas-maybe-expand` already falls back to `self-insert-command`.
