### PR TITLE
[magik-cb] Skip dedicated windows when placing the family buffer

### DIFF
--- a/magik-cb.el
+++ b/magik-cb.el
@@ -1520,11 +1520,16 @@ We also save some state for a clean exit."
 
        ((not (one-window-p t))
         ;; if there's 3 windows maybe we should try and zap the least wanted
-        ;; window.  For now we just zap the next in rotation.
-        (let
-            ((magik-cb2-win (next-window magik-cb-win 1)))
-          (set-window-buffer magik-cb2-win cb2)
-          (select-window magik-cb2-win)))
+        ;; window.  For now we just zap the next in rotation, skipping any
+        ;; dedicated windows, which refuse `set-window-buffer'.
+        (let ((magik-cb2-win (next-window magik-cb-win 1)))
+          (while (and (window-dedicated-p magik-cb2-win)
+                      (not (eq magik-cb2-win magik-cb-win)))
+            (setq magik-cb2-win (next-window magik-cb2-win 1)))
+          (if (window-dedicated-p magik-cb2-win)
+              (display-buffer cb2)
+            (set-window-buffer magik-cb2-win cb2)
+            (select-window magik-cb2-win))))
 
        ;; Now the 2 cases when "*cb*" is occupying the whole screen.
        ;; The aim is to leave "*cb*" in the half of the screen that was

--- a/magik-cb.el
+++ b/magik-cb.el
@@ -1520,16 +1520,10 @@ We also save some state for a clean exit."
 
        ((not (one-window-p t))
         ;; if there's 3 windows maybe we should try and zap the least wanted
-        ;; window.  For now we just zap the next in rotation, skipping any
-        ;; dedicated windows, which refuse `set-window-buffer'.
-        (let ((magik-cb2-win (next-window magik-cb-win 1)))
-          (while (and (window-dedicated-p magik-cb2-win)
-                      (not (eq magik-cb2-win magik-cb-win)))
-            (setq magik-cb2-win (next-window magik-cb2-win 1)))
-          (if (window-dedicated-p magik-cb2-win)
-              (display-buffer cb2)
-            (set-window-buffer magik-cb2-win cb2)
-            (select-window magik-cb2-win))))
+        ;; window.  For now we just use some other existing window.
+        (select-window
+         (display-buffer cb2 '(display-buffer-use-some-window
+                                (inhibit-same-window . t)))))
 
        ;; Now the 2 cases when "*cb*" is occupying the whole screen.
        ;; The aim is to leave "*cb*" in the half of the screen that was


### PR DESCRIPTION
## Summary
- `magik-cb2-get-window` reused whatever window `next-window` happened to land on for the family/topic buffer, then called `set-window-buffer` on it unconditionally
- If that window was dedicated (e.g. a side window from another package), this threw `Window is dedicated to '...'` and aborted the family lookup
- Now it skips dedicated windows while cycling, and falls back to `display-buffer` if no non-dedicated window is found

## Test plan
- [x] Verified in a batch Emacs harness that reproduces the scenario (a `*cb*` window plus a dedicated side window): fails with the reported error on the old code, passes cleanly with the fix, and the dedicated window's buffer is left untouched