### PR TITLE
[magik-product] Don't steal focus and report status when transmitting

### DIFF
--- a/magik-product.el
+++ b/magik-product.el
@@ -159,7 +159,8 @@ You can customize Product Mode with the `magik-product-mode-hook`.
                                            'magik-session-buffer-alist-prefix-function))
          (process (barf-if-no-gis gis))
          (filename (buffer-file-name)))
-    (pop-to-buffer gis t)
+    (message "%s loaded in buffer %s." (magik-utils-product-name) gis)
+    (display-buffer gis t)
     (magik-product-transmit-add-product filename process)
     gis))
 


### PR DESCRIPTION
## Summary
- `magik-product-transmit-buffer` used `pop-to-buffer`, which selects the session window. If that window has a stale active region left over from earlier use (e.g. a mouse selection), switching focus into it surfaces that region - visually looking like "everything got selected to the end" once new output streams in. Every other `-transmit-buffer` function (`magik-module-transmit-buffer`, and `magik-product-reinitialise` in the same file) uses `display-buffer` instead, which shows the session buffer without stealing focus.
- It also silently skipped the `"%s loaded in buffer %s."` status message that `magik-module-transmit-buffer`, `magik-msg-transmit-buffer`, `magik-trn-transmit-buffer`, and `magik-loadlist-transmit-buffer` all give after sending.

## Test plan
- [x] Verified in a batch Emacs harness with a fake session buffer holding a stale active region: with `pop-to-buffer`, the selected window switches to the session buffer, exposing the region; with `display-buffer`, focus and the active buffer stay on `product.def` and the stale region is never surfaced