### PR TITLE
session buffer a-list prioritising for completion

### DIFF
--- a/magik-cb.el
+++ b/magik-cb.el
@@ -677,12 +677,15 @@ If `cb-process' is not nil, returns that irrespective of given BUFFER."
              (error "No Class Browser is running"))))
     buf))
 
+(defun magik-cb-buffer-alist-sorted ()
+  "Return a copy of `magik-cb-buffer-alist' sorted -1, -2, etc."
+  (sort (copy-alist magik-cb-buffer-alist)
+        #'(lambda (a b) (> (car a) (car b)))))
+
 (defun magik-cb-update-tools-magik-cb-menu ()
   "Update Class Browser Processes submenu in Tools -> Magik pulldown menu."
-  (let ((magik-cb-gis-alist (sort (copy-alist (symbol-value 'magik-session-buffer-alist))
-                                  #'(lambda (a b) (< (car a) (car b))))); 1, 2 etc.
-        (magik-cb-alist     (sort (copy-alist magik-cb-buffer-alist); -1, -2, etc.
-                                  #'(lambda (a b) (> (car a) (car b)))))
+  (let ((magik-cb-gis-alist (magik-session-buffer-alist-sorted))
+        (magik-cb-alist     (magik-cb-buffer-alist-sorted))
         cb-list)
     ;; Order is such that CB of *magik* will be first see magik-session.el for more details.
     (dolist (c magik-cb-alist)

--- a/magik-completion.el
+++ b/magik-completion.el
@@ -586,9 +586,10 @@ answer its first query while `method_finder' loads its database."
 (declare-function magik-module-transmit-buffer "magik-module")
 (declare-function magik-loadlist-transmit-buffer "magik-loadlist")
 (declare-function magik-transmit-region "magik-mode")
+(declare-function magik-session-buffer-alist-sorted "magik-session")
 
 (defvar magik-cb-coding-system)
-(defvar magik-session-buffer)
+(defvar magik-session-buffer-alist)
 (defvar magik-session-prompt)
 (defvar magik-cb-in-keyword)
 
@@ -601,12 +602,11 @@ answer its first query while `method_finder' loads its database."
             (concat " *cb*" (buffer-name) "*completion*"))))
 
 (defun magik-completion--gis-buffer ()
-  "Return the active Magik session buffer name, or nil."
-  (when (boundp 'magik-session-buffer)
-    (when-let* ((buf magik-session-buffer)
-                (_ (get-buffer buf))
-                (_ (get-buffer-process buf)))
-      buf)))
+  "Return the lowest-numbered live Magik session buffer name, or nil."
+  (when (fboundp 'magik-session-buffer-alist-sorted)
+    (cl-loop for (_num . buf) in (magik-session-buffer-alist-sorted)
+             when (and buf (get-buffer buf) (get-buffer-process buf))
+             return buf)))
 
 (defun magik-completion--gis-session-idle-p (gis-buf)
   "Return non-nil if the session in GIS-BUF is idle at its prompt.
@@ -1452,9 +1452,8 @@ Intended to be called after transmitting code to the session."
 (defun magik-completion--reset-session-state (&rest _args)
   "Invalidate caches and kill all dedicated completion CB buffers.
 Also clears the dedicated-CB-connection state of every buffer with
-`magik-completion-mode' enabled.  Called when a Magik session is
-killed or (re)started, so completion doesn't serve stale candidates
-from a dead session."
+`magik-completion-mode' enabled.
+Invalidating cache twice helped with some caching issues."
   (magik-completion-invalidate-cache)
   (dolist (buf (buffer-list))
     (when (buffer-local-value 'magik-completion-mode buf)
@@ -1473,7 +1472,8 @@ from a dead session."
                  (string-suffix-p "*completion*" name))
         (when-let* ((proc (get-buffer-process buf)))
           (delete-process proc))
-        (kill-buffer buf)))))
+        (kill-buffer buf))))
+  (magik-completion-invalidate-cache))
 
 ;;; --- Setup ---
 
@@ -1519,6 +1519,8 @@ one, rather than only functions already bound at this point."
   ;; Forward advice: takes effect once magik-session is loaded.
   (advice-add 'magik-session-kill-process :after
               #'magik-completion--reset-session-state)
+  (advice-add 'magik-session-set-priority :after
+              #'magik-completion--reset-session-state)
   (add-hook 'magik-session-start-process-post-hook
             #'magik-completion--reset-session-state))
 
@@ -1527,6 +1529,8 @@ one, rather than only functions already bound at this point."
   (dolist (fn magik-completion--capf-functions)
     (remove-hook 'completion-at-point-functions fn t))
   (advice-remove 'magik-session-kill-process
+                 #'magik-completion--reset-session-state)
+  (advice-remove 'magik-session-set-priority
                  #'magik-completion--reset-session-state)
   (remove-hook 'magik-session-start-process-post-hook
                #'magik-completion--reset-session-state))

--- a/magik-session.el
+++ b/magik-session.el
@@ -429,6 +429,32 @@ Return a list of all the components of the COMMAND."
       (error "No Magik session buffer"))
     buf))
 
+(defun magik-session-buffer-alist-sorted ()
+  "Return a copy of `magik-session-buffer-alist' sorted by session number."
+  (sort (copy-alist magik-session-buffer-alist)
+        #'(lambda (a b) (< (car a) (car b)))))
+
+(defun magik-session-set-priority (buffer priority)
+  "Renumber Magik session BUFFER to PRIORITY in `magik-session-buffer-alist'.
+Lower numbers sort first in the Tools -> Magik menu, are reached with
+\\[magik-session] and a matching numeric prefix arg, and are preferred by
+`magik-completion' when picking which live session to query.  If another
+session already holds PRIORITY, the two swap numbers."
+  (interactive
+   (list (completing-read "Magik session buffer: "
+                          (magik-utils-buffer-mode-list 'magik-session-mode)
+                          nil t nil nil (buffer-name))
+         (read-number "New priority (1 = highest): " 1)))
+  (let ((entry (rassoc buffer magik-session-buffer-alist))
+        (other (assq priority magik-session-buffer-alist)))
+    (unless entry
+      (error "%s is not a registered Magik session buffer" buffer))
+    (let ((old-priority (car entry)))
+      (setcar entry priority)
+      (when (and other (not (eq other entry)))
+        (setcar other old-priority)))
+    (message "%s is now Magik session %d" buffer priority)))
+
 (defun magik-session-command-display (command)
   "Return shortened Magik session COMMAND suitable for display."
   (if (stringp command) ; defensive programming. Should be a string but need to avoid errors
@@ -445,8 +471,7 @@ Return a list of all the components of the COMMAND."
 
 (defun magik-session-update-tools-magik-gis-menu ()
   "Update Magik Session processes submenu in Tools -> Magik pulldown menu."
-  (let* ((magik-session-alist (sort (copy-alist magik-session-buffer-alist)
-                                    #'(lambda (a b) (< (car a) (car b)))))
+  (let* ((magik-session-alist (magik-session-buffer-alist-sorted))
          magik-session-list)
     (dolist (c magik-session-alist)
       (let ((i   (car c))
@@ -600,6 +625,7 @@ Entry to this mode runs `magik-session-mode-hook`.
     [,"External Shell Process"           magik-session-shell                     t]
     [,"Kill Magik Process"               magik-session-kill-process              (and magik-session-process
                                                                                       (eq (process-status magik-session-process) 'run))]
+    [,"Set Session Priority..."          magik-session-set-priority              t]
     (,"Magik Session Command History")
     "---"
     (,"Toggle..."


### PR DESCRIPTION
## Summary

- Extracts the repeated `(sort (copy-alist ...) ...)` pattern used to order session/CB entries into two reusable helpers — `magik-session-buffer-alist-sorted` (`magik-session.el`) and `magik-cb-buffer-alist-sorted` (`magik-cb.el`) — and updates both existing menu builders (`magik-session-update-tools-magik-gis-menu`, `magik-cb-update-tools-magik-cb-menu`) to use them instead of duplicating the sort inline.
- Adds `magik-session-set-priority` (interactive command, also exposed as "Set Session Priority..." in Tools → Magik → Magik Session): renumbers a session's slot in `magik-session-buffer-alist`, swapping with whichever session currently holds the target number. Session numbers already drive the Tools menu order and the `M-N f2 z` prefix keys, so this gives one consistent lever for session priority instead of a separate parallel concept.
- Reworks `magik-completion--gis-buffer` to scan `magik-session-buffer-alist` (via the new sorted helper) and return the lowest-numbered *live* session, instead of only checking the single global `magik-session-buffer` default. Completion's dedicated CB process no longer stalls just because the "default" session died while another session is still running.
- Wires `magik-session-set-priority` into `magik-completion`'s existing session-state reset (`advice-add 'magik-session-set-priority :after #'magik-completion--reset-session-state`, mirrored in `--enable`/`--disable`), matching the existing `magik-session-kill-process` advice — so reprioritizing drops every buffer's cached CB connection and forces it to re-resolve against the new preferred session on next use, rather than continuing to talk to the old one silently.
- `magik-completion--reset-session-state` now calls `magik-completion-invalidate-cache` a second time at the end of the function (docstring: "Invalidating cache twice helped with some caching issues").

## Tested:

- [x]  With `magik-completion-mode` enabled and a CB connection already established in an editing buffer, run `magik-session-set-priority`; confirm the next completion request re-establishes its CB connection against the newly-prioritized session

- [x] Kill the higher-priority session's process from inside Magik (not via `kill-buffer`); confirm completion still resolves against the next live session
