### PR TITLE
[magik-completion] minor modes reworked.

### DIFF
--- a/magik-completion.el
+++ b/magik-completion.el
@@ -31,6 +31,10 @@
   (require 'cl-lib))
 
 (require 'magik-utils)
+(require 'magik-mode)
+(require 'magik-loadlist)
+(require 'magik-product)
+(require 'magik-module)
 
 ;; Tree-sitter functions (Emacs 29+, only used when available)
 (declare-function treesit-parser-list "treesit")
@@ -1485,6 +1489,7 @@ Invalidating cache twice helped with some caching issues."
     'magik-loadlist-transmit-buffer-post-hook
     'magik-transmit-region-post-hook))
 
+;;;###autoload
 (define-minor-mode magik-completion-mode
   "Toggle Magik completion in the current buffer."
   :lighter " MagikComp"
@@ -1500,6 +1505,7 @@ Invalidating cache twice helped with some caching issues."
   (dolist (fn magik-completion--capf-functions)
     (remove-hook 'completion-at-point-functions fn t)))
 
+;;;###autoload
 (define-globalized-minor-mode global-magik-completion-mode
   magik-completion-mode
   magik-completion--turn-on

--- a/magik-completion.el
+++ b/magik-completion.el
@@ -45,13 +45,6 @@
   "Completion-at-point support for Magik."
   :group 'magik)
 
-(defcustom magik-completion-enabled t
-  "When non-nil, enable Magik `completion-at-point'.
-Set to nil before mode activation to disable, or use
-`magik-completion-mode' to toggle interactively."
-  :type 'boolean
-  :group 'magik-completion)
-
 (defcustom magik-completion-enable-keywords t
   "When non-nil, include Magik keywords in completion candidates."
   :type 'boolean
@@ -642,7 +635,8 @@ the session answers."
                (cb-buf (magik-completion--cb-buffer)))
           (condition-case nil
               (let ((proc (cl-letf (((symbol-function 'magik-cb-mode)
-                                     #'fundamental-mode))
+                                        #'fundamental-mode
+                                     ))
                             (magik-cb-get-process-create
                              cb-buf
                              #'magik-completion--cb-filter
@@ -722,7 +716,7 @@ PARSE-FN override the default dispatch, see `magik-completion--cb-filter'."
            (cl-incf magik-completion--cb-generation))))
     (process-send-string (get-buffer-process buf) command)
     (run-at-time magik-completion-cb-timeout nil
-                 #'magik-completion--cb-timeout buf generation)))
+                 'magik-completion--cb-timeout buf generation)))
 
 (defun magik-completion--cb-timeout (buf generation)
   "Give up on BUF's in-flight query if GENERATION is still current.
@@ -749,7 +743,7 @@ Then dispatch the next queued query on this connection, if any."
     (setq magik-completion--cb-on-response nil)
     (funcall callback result))
   (when-let* ((next (pop magik-completion--cb-queue)))
-    (apply #'magik-completion--cb-dispatch (current-buffer) next)))
+    (apply 'magik-completion--cb-dispatch (current-buffer) next)))
 
 (declare-function corfu--post-command "corfu")
 
@@ -960,7 +954,7 @@ Returns nil if the class has no comment or wasn't found."
               (body-end (magik-completion--class-comment-nth-line-end str (1+ n))))
     (string-trim (substring str (1+ first-nl) body-end))))
 
-(defvar magik-completion--class-comment-cache (make-hash-table :test #'equal)
+(defvar magik-completion--class-comment-cache (make-hash-table :test 'equal)
   "Cache: qualified class name -> its comment text (or `none') from CB.")
 
 (defvar magik-completion--class-comment-fetch-pending nil
@@ -1263,8 +1257,8 @@ Inserts parameters as yasnippet when STATUS is `finished'."
                     (concat (when-let* ((ann (get-text-property 0 'magik-annotation c)))
                               (concat " " ann))
                             " (magik-method)"))
-                  :company-doc-buffer #'magik-completion--doc-buffer
-                  :exit-function #'magik-completion--exit-function)))))))
+                  :company-doc-buffer 'magik-completion--doc-buffer
+                  :exit-function 'magik-completion--exit-function)))))))
 
 (defun magik-completion--tag-kind (candidates kind)
   "Return CANDIDATES with a `magik-kind' text property set to KIND.
@@ -1352,7 +1346,7 @@ procedures/dynamics, and yasnippet template keys."
               (when magik-completion-enable-cb
                 (magik-completion--tag-kind (magik-completion--query-classes) 'class))
               (when magik-completion-enable-cb
-                (mapcar #'magik-completion--tag-global
+                (mapcar 'magik-completion--tag-global
                         (magik-completion--query-globals)))))
             (plain
              (append
@@ -1361,16 +1355,16 @@ procedures/dynamics, and yasnippet template keys."
                  (magik-completion--scan-local-variables) 'variable))
               (when magik-completion-enable-snippets
                 (magik-completion--tag-kind
-                 (delq nil (mapcar #'yas--template-key
+                 (delq nil (mapcar 'yas--template-key
                                     (magik-completion--snippet-templates)))
                  'snippet)))))
         (when (or qualifiable plain)
           (list beg end (magik-completion--symbol-table qualifiable plain)
                 :exclusive 'no
-                :company-kind #'magik-completion--symbol-kind
-                :annotation-function #'magik-completion--symbol-annotation
-                :company-doc-buffer #'magik-completion--symbol-doc-buffer
-                :exit-function #'magik-completion--symbol-exit-function)))))))
+                :company-kind 'magik-completion--symbol-kind
+                :annotation-function 'magik-completion--symbol-annotation
+                :company-doc-buffer 'magik-completion--symbol-doc-buffer
+                :exit-function 'magik-completion--symbol-exit-function)))))))
 
 ;;; --- Condition completion ---
 
@@ -1483,66 +1477,53 @@ Invalidating cache twice helped with some caching issues."
     magik-completion-at-point-slots
     magik-completion-at-point-character
     magik-completion-at-point-symbol)
-  "List of Magik CAPF functions, lowest priority first.
-`magik-completion-at-point-symbol' is listed last so
-`magik-completion--enable' (which prepends each entry) tries it before
-the narrower dot- and condition-context backends.")
+  "List of Magik CAPF functions, lowest priority first.")
 
-(defconst magik-completion--transmit-functions
-  '((magik-product-transmit-buffer . magik-product)
-    (magik-module-transmit-buffer . magik-module)
-    (magik-loadlist-transmit-buffer . magik-loadlist)
-    (magik-transmit-region . magik-mode))
-  "Alist of (FUNCTION . FEATURE) that send code to a Magik session.
-Each FUNCTION should invalidate the completion cache when called.
-FEATURE is the file defining FUNCTION, so advising it can be deferred
-until that file is actually loaded.")
-
-(defun magik-completion--advise-transmit-functions ()
-  "Advise every function in `magik-completion--transmit-functions'.
-This is done once, globally, independent of `magik-completion-mode':
-the completion cache is global state, not buffer-local, so a single
-buffer disabling the mode must not stop other buffers' transmitted
-code from invalidating it.  `with-eval-after-load' also ensures a
-function gets advised even if its defining file is loaded after this
-one, rather than only functions already bound at this point."
-  (dolist (entry magik-completion--transmit-functions)
-    (with-eval-after-load (cdr entry)
-      (advice-add (car entry) :after #'magik-completion--invalidate-cache))))
-
-(magik-completion--advise-transmit-functions)
-
-(defun magik-completion--enable ()
-  "Add Magik CAPF functions to the current buffer."
-  (dolist (fn magik-completion--capf-functions)
-    (add-hook 'completion-at-point-functions fn nil t))
-  (add-hook 'magik-session-kill-process-post-hook
-            #'magik-completion--reset-session-state nil t)
-  (add-hook 'magik-session-start-process-post-hook
-            #'magik-completion--reset-session-state nil t))
-
-(defun magik-completion--disable ()
-  "Remove Magik CAPF functions from the current buffer."
-  (dolist (fn magik-completion--capf-functions)
-    (remove-hook 'completion-at-point-functions fn t))
-  (remove-hook 'magik-session-kill-process-post-hook
-            #'magik-completion--reset-session-state t)
-  (remove-hook 'magik-session-start-process-post-hook
-               #'magik-completion--reset-session-state t))
+(defvar magik-completion--transmit-hooks
+  '('magik-product-transmit-buffer-post-hook
+    'magik-module-transmit-buffer-post-hook
+    'magik-loadlist-transmit-buffer-post-hook
+    'magik-transmit-region-post-hook))
 
 (define-minor-mode magik-completion-mode
-  "Toggle Magik `completion-at-point' support in the current buffer."
-  :lighter " MagikC"
+  "Toggle Magik completion in the current buffer."
+  :lighter " MagikComp"
   (if magik-completion-mode
-      (magik-completion--enable)
-    (magik-completion--disable)))
+      (magik-completion--local-enable)
+    (magik-completion--local-disable)))
 
-(defun magik-completion-setup ()
-  "Add Magik CAPF functions to the current buffer.
-Intended to be called from `magik-mode-hook' or `magik-session-mode-hook'.
-Respects `magik-completion-enabled'."
-  (when magik-completion-enabled
+(defun magik-completion--local-enable ()
+  (dolist (fn magik-completion--capf-functions)
+    (add-hook 'completion-at-point-functions fn t)))
+
+(defun magik-completion--local-disable ()
+  (dolist (fn magik-completion--capf-functions)
+    (remove-hook 'completion-at-point-functions fn t)))
+
+(define-globalized-minor-mode global-magik-completion-mode
+  magik-completion-mode
+  magik-completion--turn-on
+  (if global-magik-completion-mode
+      (magik-completion--global-enable)
+    (magik-completion--global-disable)))
+
+(defun magik-completion--turn-on ()
+  (when (derived-mode-p 'magik-mode)
     (magik-completion-mode 1)))
 
-(provide 'magik-completion)
+(defun magik-completion--global-enable ()
+  (add-hook 'magik-session-kill-process-post-hook
+            'magik-completion--reset-session-state nil t)
+  (add-hook 'magik-session-start-process-post-hook
+            'magik-completion--reset-session-state nil t)
+  (dolist (hook-var magik-completion--transmit-hooks)
+    (add-hook hook-var 'magik-completion-invalidate-cache)))
+
+(defun magik-completion--global-disable ()
+  (remove-hook 'magik-session-kill-process-post-hook
+               'magik-completion--reset-session-state t)
+  (remove-hook 'magik-session-start-process-post-hook
+               'magik-completion--reset-session-state t))
+
+    (provide 'magik-completion)
 ;;; magik-completion.el ends here

--- a/magik-completion.el
+++ b/magik-completion.el
@@ -1495,7 +1495,7 @@ Invalidating cache twice helped with some caching issues."
 (defun magik-completion--local-enable ()
   "Add the Magik CAPF functions to `completion-at-point-functions'."
   (dolist (fn magik-completion--capf-functions)
-    (add-hook 'completion-at-point-functions fn t)))
+    (add-hook 'completion-at-point-functions fn nil t)))
 
 (defun magik-completion--local-disable ()
   "Remove the Magik CAPF functions from `completion-at-point-functions'."

--- a/magik-completion.el
+++ b/magik-completion.el
@@ -635,8 +635,7 @@ the session answers."
                (cb-buf (magik-completion--cb-buffer)))
           (condition-case nil
               (let ((proc (cl-letf (((symbol-function 'magik-cb-mode)
-                                        #'fundamental-mode
-                                     ))
+                                     'fundamental-mode))
                             (magik-cb-get-process-create
                              cb-buf
                              #'magik-completion--cb-filter

--- a/magik-completion.el
+++ b/magik-completion.el
@@ -1516,24 +1516,19 @@ one, rather than only functions already bound at this point."
   "Add Magik CAPF functions to the current buffer."
   (dolist (fn magik-completion--capf-functions)
     (add-hook 'completion-at-point-functions fn nil t))
-  ;; Forward advice: takes effect once magik-session is loaded.
-  (advice-add 'magik-session-kill-process :after
-              #'magik-completion--reset-session-state)
-  (advice-add 'magik-session-set-priority :after
-              #'magik-completion--reset-session-state)
+  (add-hook 'magik-session-kill-process-post-hook
+            #'magik-completion--reset-session-state nil t)
   (add-hook 'magik-session-start-process-post-hook
-            #'magik-completion--reset-session-state))
+            #'magik-completion--reset-session-state nil t))
 
 (defun magik-completion--disable ()
   "Remove Magik CAPF functions from the current buffer."
   (dolist (fn magik-completion--capf-functions)
     (remove-hook 'completion-at-point-functions fn t))
-  (advice-remove 'magik-session-kill-process
-                 #'magik-completion--reset-session-state)
-  (advice-remove 'magik-session-set-priority
-                 #'magik-completion--reset-session-state)
+  (remove-hook 'magik-session-kill-process-post-hook
+            #'magik-completion--reset-session-state t)
   (remove-hook 'magik-session-start-process-post-hook
-               #'magik-completion--reset-session-state))
+               #'magik-completion--reset-session-state t))
 
 (define-minor-mode magik-completion-mode
   "Toggle Magik `completion-at-point' support in the current buffer."

--- a/magik-completion.el
+++ b/magik-completion.el
@@ -31,10 +31,6 @@
   (require 'cl-lib))
 
 (require 'magik-utils)
-(require 'magik-mode)
-(require 'magik-loadlist)
-(require 'magik-product)
-(require 'magik-module)
 
 ;; Tree-sitter functions (Emacs 29+, only used when available)
 (declare-function treesit-parser-list "treesit")
@@ -1484,10 +1480,10 @@ Invalidating cache twice helped with some caching issues."
   "List of Magik CAPF functions, lowest priority first.")
 
 (defvar magik-completion--transmit-hooks
-  '('magik-product-transmit-buffer-post-hook
-    'magik-module-transmit-buffer-post-hook
-    'magik-loadlist-transmit-buffer-post-hook
-    'magik-transmit-region-post-hook))
+  '(magik-product-transmit-buffer-post-hook
+    magik-module-transmit-buffer-post-hook
+    magik-loadlist-transmit-buffer-post-hook
+    magik-transmit-region-post-hook))
 
 ;;;###autoload
 (define-minor-mode magik-completion-mode
@@ -1498,10 +1494,12 @@ Invalidating cache twice helped with some caching issues."
     (magik-completion--local-disable)))
 
 (defun magik-completion--local-enable ()
+  "Add the Magik CAPF functions to `completion-at-point-functions'."
   (dolist (fn magik-completion--capf-functions)
     (add-hook 'completion-at-point-functions fn t)))
 
 (defun magik-completion--local-disable ()
+  "Remove the Magik CAPF functions from `completion-at-point-functions'."
   (dolist (fn magik-completion--capf-functions)
     (remove-hook 'completion-at-point-functions fn t)))
 
@@ -1514,22 +1512,30 @@ Invalidating cache twice helped with some caching issues."
     (magik-completion--global-disable)))
 
 (defun magik-completion--turn-on ()
-  (when (derived-mode-p 'magik-mode)
+  "Turn on `magik-completion-mode' in Magik source and session buffers."
+  (when (derived-mode-p 'magik-base-mode 'magik-session-mode)
     (magik-completion-mode 1)))
 
 (defun magik-completion--global-enable ()
+  "Add the hooks backing `global-magik-completion-mode'."
   (add-hook 'magik-session-kill-process-post-hook
-            'magik-completion--reset-session-state nil t)
+            'magik-completion--reset-session-state)
   (add-hook 'magik-session-start-process-post-hook
-            'magik-completion--reset-session-state nil t)
+            'magik-completion--reset-session-state)
   (dolist (hook-var magik-completion--transmit-hooks)
     (add-hook hook-var 'magik-completion-invalidate-cache)))
 
 (defun magik-completion--global-disable ()
+  "Remove the hooks backing `global-magik-completion-mode'."
   (remove-hook 'magik-session-kill-process-post-hook
-               'magik-completion--reset-session-state t)
+               'magik-completion--reset-session-state)
   (remove-hook 'magik-session-start-process-post-hook
-               'magik-completion--reset-session-state t))
+               'magik-completion--reset-session-state)
+  (dolist (hook-var magik-completion--transmit-hooks)
+    (remove-hook hook-var 'magik-completion-invalidate-cache)))
 
-    (provide 'magik-completion)
+;;;###autoload
+(global-magik-completion-mode 1)
+
+(provide 'magik-completion)
 ;;; magik-completion.el ends here

--- a/magik-completion.el
+++ b/magik-completion.el
@@ -1521,6 +1521,8 @@ Invalidating cache twice helped with some caching issues."
             'magik-completion--reset-session-state)
   (add-hook 'magik-session-start-process-post-hook
             'magik-completion--reset-session-state)
+  (add-hook 'magik-session-set-priority-post-hook
+            'magik-completion--reset-session-state)
   (dolist (hook-var magik-completion--transmit-hooks)
     (add-hook hook-var 'magik-completion-invalidate-cache)))
 
@@ -1529,6 +1531,8 @@ Invalidating cache twice helped with some caching issues."
   (remove-hook 'magik-session-kill-process-post-hook
                'magik-completion--reset-session-state)
   (remove-hook 'magik-session-start-process-post-hook
+               'magik-completion--reset-session-state)
+  (remove-hook 'magik-session-set-priority-post-hook
                'magik-completion--reset-session-state)
   (dolist (hook-var magik-completion--transmit-hooks)
     (remove-hook hook-var 'magik-completion-invalidate-cache)))

--- a/magik-loadlist.el
+++ b/magik-loadlist.el
@@ -32,6 +32,11 @@ Initial ^ and final $ is automatically added in `loadlist-ignore'."
   :group 'magik-loadlist
   :type  '(repeat regexp))
 
+(defcustom magik-loadlist-transmit-buffer-post-hook nil
+  "*Hook run after transmitting to the the process."
+  :group 'magik-loadlist
+  :type 'hook)
+
 (defgroup magik-loadlist-faces nil
   "Faces for displaying text in a Magik load_list file."
   :group 'magik-loadlist)
@@ -220,7 +225,8 @@ With a prefix ARG accept all changes without prompting."
      process
      (concat
       (magik-function "load_file_list" dir 'unset file)
-      "$\n"))))
+      "$\n"))
+    (run-hooks 'magik-loadlist-transmit-buffer-post-hook)))
 
 (defun magik-loadlist-drag-n-drop-load (gis filename)
   "Interface to Drag and Drop GIS mode.

--- a/magik-mode.el
+++ b/magik-mode.el
@@ -37,7 +37,6 @@
 (require 'yasnippet)
 (require 'magik-doc-gen)
 (require 'magik-template)
-(require 'magik-completion)
 
 (defgroup magik nil
   "Customise Magik Language group."

--- a/magik-mode.el
+++ b/magik-mode.el
@@ -37,6 +37,7 @@
 (require 'yasnippet)
 (require 'magik-doc-gen)
 (require 'magik-template)
+(require 'magik-completion)
 
 (defgroup magik nil
   "Customise Magik Language group."

--- a/magik-mode.el
+++ b/magik-mode.el
@@ -48,6 +48,11 @@
   :group 'magik
   :type  'boolean)
 
+(defcustom magik-transmit-region-post-hook nil
+  "*Hook run after transmitting to the the process."
+  :group 'magik
+  :type 'hook)
+
 (defcustom magik-under-as-char t
   "*Non-nil means that the _ (underline) should be treated as word char."
   :group 'magik
@@ -112,7 +117,6 @@ concrete implementations."
     (abbrev-mode t)
     (yas-minor-mode t))
 
-  (magik-completion-setup)
   (imenu-add-menubar-index))
 
 ;;;###autoload
@@ -1251,7 +1255,8 @@ Magik, another file shall be written."
      (magik-package-line))
    (lambda (f) (magik-function "load_file" f 'unset (or (buffer-file-name) 'unset)))
    (lambda (f) (magik-function "system.unlink" f 'false 'true))
-   beg))
+   beg)
+  (run-hooks 'magik-transmit-region-post-hook))
 (defalias 'transmit-region-to-magik 'magik-transmit-region)
 
 (defun magik-package-line ()

--- a/magik-module.el
+++ b/magik-module.el
@@ -43,6 +43,11 @@
   :group 'magik-module
   :type  'boolean)
 
+(defcustom magik-module-transmit-buffer-post-hook nil
+  "*Hook run after transmitting to the the process."
+  :group 'magik-module
+  :type 'hook)
+
 ;; Imenu configuration
 (defvar magik-module-imenu-generic-expression
   '((nil "^\\(\\sw+\\)\\s-*\n\\(.\\|\n\\)*\nend\\s-*$" 1))
@@ -303,6 +308,7 @@ a standalone module."
     (message "%s loaded in buffer %s." (magik-utils-module-name) gis)
     (display-buffer gis t)
     (magik-module-transmit-load-module filename process)
+    (run-hooks 'magik-module-transmit-buffer-post-hook)
     gis))
 
 (defun magik-module-drag-n-drop-load (gis filename)

--- a/magik-product.el
+++ b/magik-product.el
@@ -61,6 +61,11 @@ See `imenu-generic-expression'.")
   "Font Lock mode face used to display a product type."
   :group 'magik-product-faces)
 
+(defcustom magik-product-transmit-buffer-post-hook nil
+  "*Hook run after transmitting to the the process."
+  :group 'magik-product
+  :type 'hook)
+
 ;; Font-lock configuration
 (defcustom magik-product-font-lock-keywords
   (list
@@ -162,6 +167,7 @@ You can customize Product Mode with the `magik-product-mode-hook`.
     (message "%s loaded in buffer %s." (magik-utils-product-name) gis)
     (display-buffer gis t)
     (magik-product-transmit-add-product filename process)
+    (run-hooks 'magik-product-transmit-buffer-post-hook)
     gis))
 
 (defun magik-product-drag-n-drop-load (gis filename)

--- a/magik-session.el
+++ b/magik-session.el
@@ -602,8 +602,6 @@ Entry to this mode runs `magik-session-mode-hook`.
   (with-current-buffer (get-buffer-create (concat " *filter*" (buffer-name)))
     (erase-buffer))
 
-  (magik-completion-setup)
-
   (add-hook 'before-change-functions #'magik-session--prepare-for-edit-cmd nil t)
   (add-hook 'menu-bar-update-hook #'magik-session-update-magik-session-menu nil t)
   (add-hook 'menu-bar-update-hook #'magik-session-update-tools-magik-gis-menu nil t)

--- a/magik-session.el
+++ b/magik-session.el
@@ -195,6 +195,16 @@ If nil, allow matching anywhere in the line."
   :group 'magik-session
   :type 'hook)
 
+(defcustom magik-session-kill-process-pre-hook nil
+  "*Hook run before killing the process."
+  :group 'magik-session
+  :type 'hook)
+
+(defcustom magik-session-kill-process-post-hook nil
+  "*Hook run after killing the process."
+  :group 'magik-session
+  :type 'hook)
+
 (defcustom magik-session-auto-insert-dollar nil
   "If t, automatically insert a $ after each valid Magik statement."
   :group 'magik-session
@@ -838,6 +848,7 @@ there is not, prompt for a command to run, and then run it."
 (defun magik-session-kill-process ()
   "Kill the current Magik process."
   (interactive)
+  (run-hooks 'magik-session-kill-process-pre-hook)
   (if (and magik-session-process
            (eq (process-status magik-session-process) 'run)
            (y-or-n-p "Kill the Magik process? "))
@@ -845,7 +856,9 @@ there is not, prompt for a command to run, and then run it."
         (kill-process magik-session-process)
         (sit-for 0.1)
         (if (eq status (process-status magik-session-process))
-            (insert "\nMagik is still busy and will exit at an appropriate point. Please be patient... \n")))))
+            (insert "\nMagik is still busy and will exit at an appropriate point. Please be patient... \n"))
+        (run-hooks 'magik-session-kill-process-post-hook)
+        )))
 
 (defun magik-session-query-interrupt-shell-subjob ()
   "Ask and then `comint-interrupt-subjob'."

--- a/magik-session.el
+++ b/magik-session.el
@@ -205,6 +205,11 @@ If nil, allow matching anywhere in the line."
   :group 'magik-session
   :type 'hook)
 
+(defcustom magik-session-set-priority-post-hook nil
+  "*Hook run after changing the magik session priority."
+  :group 'magik-session
+  :type 'hook)
+
 (defcustom magik-session-auto-insert-dollar nil
   "If t, automatically insert a $ after each valid Magik statement."
   :group 'magik-session
@@ -463,7 +468,8 @@ session already holds PRIORITY, the two swap numbers."
       (setcar entry priority)
       (when (and other (not (eq other entry)))
         (setcar other old-priority)))
-    (message "%s is now Magik session %d" buffer priority)))
+    (message "%s is now Magik session %d" buffer priority))
+  (run-hooks 'magik-session-set-priority-post-hook))
 
 (defun magik-session-command-display (command)
   "Return shortened Magik session COMMAND suitable for display."

--- a/test/magik-completion-test.el
+++ b/test/magik-completion-test.el
@@ -9,6 +9,8 @@
 
 (require 'test-helper)
 (require 'cl-lib)
+(require 'magik-mode)
+(require 'magik-session)
 (require 'magik-completion)
 
 ;;; Helpers
@@ -852,6 +854,63 @@ subprocess buffers still holds alongside the new per-buffer reset."
       (rename-buffer " *cb*fake.magik*completion*"))
     (magik-completion--reset-session-state)
     (should-not (get-buffer " *cb*fake.magik*completion*"))))
+
+;;; global-magik-completion-mode
+
+(defmacro magik-completion-test--with-global-mode (&rest body)
+  "Eval BODY with `global-magik-completion-mode' enabled.
+Always disables it again afterwards, regardless of errors, so a
+failing assertion here cannot leak the global toggle into unrelated
+tests that run later in the same Emacs process."
+  (declare (indent 0))
+  `(unwind-protect
+       (progn
+         (global-magik-completion-mode 1)
+         ,@body)
+     (global-magik-completion-mode -1)))
+
+(ert-deftest global-magik-completion-mode--enables-in-existing-magik-mode-buffer ()
+  "Enabling the global mode turns on the local mode in a Magik buffer
+that already exists at the time it's enabled."
+  (with-temp-buffer
+    (magik-mode)
+    (magik-completion-test--with-global-mode
+      (should magik-completion-mode))))
+
+(ert-deftest global-magik-completion-mode--enables-in-new-magik-mode-buffer ()
+  "A Magik buffer created after the global mode is already on gets the
+local mode turned on automatically."
+  (magik-completion-test--with-global-mode
+    (with-temp-buffer
+      (magik-mode)
+      (should magik-completion-mode))))
+
+(ert-deftest global-magik-completion-mode--enables-in-magik-session-mode-buffer ()
+  "The global mode also turns on the local mode in Magik session buffers."
+  (magik-completion-test--with-global-mode
+    (with-temp-buffer
+      (magik-session-mode)
+      (should magik-completion-mode))))
+
+(ert-deftest global-magik-completion-mode--does-not-enable-in-unrelated-buffer ()
+  "Buffers whose major mode is unrelated to Magik are left alone."
+  (magik-completion-test--with-global-mode
+    (with-temp-buffer
+      (fundamental-mode)
+      (should-not magik-completion-mode))))
+
+(ert-deftest global-magik-completion-mode--disabling-turns-off-local-mode ()
+  "Disabling the global mode turns the local mode back off in a buffer
+where it was enabled through it."
+  (with-temp-buffer
+    (magik-mode)
+    (unwind-protect
+        (progn
+          (global-magik-completion-mode 1)
+          (should magik-completion-mode)
+          (global-magik-completion-mode -1)
+          (should-not magik-completion-mode))
+      (global-magik-completion-mode -1))))
 
 (provide 'magik-completion-test)
 ;;; magik-completion-test.el ends here


### PR DESCRIPTION
- Replaces the advice-based wiring between `magik-completion.el` and `magik-session`/`magik-mode`/`magik-loadlist`/`magik-product`/`magik-module` with new hook variables (`magik-session-kill-process-pre-hook`/`-post-hook`, `magik-*-transmit-buffer-post-hook`) that those files run themselves.
- Reworks `magik-completion-mode` into  local/global minor-mode pair: a buffer-local `magik-completion-mode` plus `define-globalized-minor-mode global-magik-completion-mode`, which turns itself on in any `magik-base-mode` or `magik-session-mode` buffer (`magik-completion--turn-on`) instead of relying on `magik-completion-setup`.
- `global-magik-completion-mode` is auto-enabled at load time (`;;;###autoload (global-magik-completion-mode 1)`), and its enable/disable functions attach/detach the session-reset and cache-invalidation hooks globally rather than per-buffer.
- Removes the now-unused `magik-completion-enabled` defcustom and the `magik-completion-setup` calls from `magik-mode.el`/`magik-session.el`.
- Adds ERT coverage for `global-magik-completion-mode`