### PR TITLE
Replace placeholder TODO faces with Magik-specific faces

### DIFF
--- a/magik-cb.el
+++ b/magik-cb.el
@@ -336,12 +336,12 @@ Not used yet.")
   :group 'magik-cb-faces)
 
 (defface magik-cb2-thermometer-on-face
-  '((t :inherit font-lock-type-face)) ;; TODO: Switch to a Magik-specific face?
+  '((t :inherit magik-class-face))
   "Font Lock mode face used to display a thermometer variable that is on."
   :group 'magik-cb-faces)
 
 (defface magik-cb2-thermometer-off-face
-  '((t :inherit font-lock-constant-face)) ;; TODO: Switch to a Magik-specific face?
+  '((t :inherit magik-constant-face))
   "Font Lock mode face used to display a thermometer variable that is off."
   :group 'magik-cb-faces)
 

--- a/magik-loadlist.el
+++ b/magik-loadlist.el
@@ -42,12 +42,12 @@ Initial ^ and final $ is automatically added in `loadlist-ignore'."
   :group 'magik-loadlist)
 
 (defface magik-loadlist-file-face
-  '((t :inherit font-lock-variable-name-face)) ;; TODO: Switch to a Magik-specific face?
+  '((t :inherit magik-variable-face))
   "Font Lock mode face used to display file name."
   :group 'magik-loadlist-faces)
 
 (defface magik-loadlist-folder-face
-  '((t :inherit font-lock-keyword-face)) ;; TODO: Switch to a Magik-specific face?
+  '((t :inherit magik-keyword-statements-face))
   "Font Lock mode face used to display folder name."
   :group 'magik-loadlist-faces)
 

--- a/magik-loadlist.el
+++ b/magik-loadlist.el
@@ -21,6 +21,7 @@
 
 (require 'compat)
 (require 'font-lock)
+(require 'magik-mode)
 
 (defgroup magik-loadlist nil
   "Customise Magik load_list.txt files group."

--- a/magik-session.el
+++ b/magik-session.el
@@ -145,7 +145,7 @@ that use command string matching are not affected by this setting."
   :group 'magik-session-faces)
 
 (defface magik-session-prompt-face
-  '((t :inherit font-lock-type-face)) ;; TODO: Switch to a Magik-specific face?
+  '((t :inherit magik-class-face))
   "Font Lock mode face used to display the Magik Prompt."
   :group 'magik-session-faces)
 

--- a/test/magik-loadlist-test.el
+++ b/test/magik-loadlist-test.el
@@ -10,6 +10,18 @@
 (require 'magik-loadlist)
 (require 'magik-msg)
 
+;;; magik-loadlist faces
+
+(ert-deftest magik-loadlist-file-face--resolves ()
+  "The face must resolve on its own, without the caller having loaded
+`magik-mode' first (see `magik-loadlist''s own require of `magik-mode')."
+  (should (facep 'magik-loadlist-file-face)))
+
+(ert-deftest magik-loadlist-folder-face--resolves ()
+  "The face must resolve on its own, without the caller having loaded
+`magik-mode' first (see `magik-loadlist''s own require of `magik-mode')."
+  (should (facep 'magik-loadlist-folder-face)))
+
 ;;; magik-loadlist-file-data
 
 (ert-deftest magik-loadlist-file-data--lowercases-name ()


### PR DESCRIPTION
magik-cb.el, magik-loadlist.el, and magik-session.el each defined a face that inherited from a generic font-lock-*-face and left a TODO comment asking whether it should switch to a Magik-specific face instead.

Now that magik-class-face, magik-constant-face, magik-variable-face, and magik-keyword-statements-face are already defined in magik-mode.el, this swaps those generic faces out for the Magik-specific ones and drops the TODOs:

- magik-cb.el: magik-cb2-thermometer-on-face now inherits magik-class-face; magik-cb2-thermometer-off-face now inherits magik-constant-face
- magik-loadlist.el: magik-loadlist-file-face now inherits magik-variable-face; magik-loadlist-folder-face now inherits magik-keyword-statements-face
- magik-session.el: magik-session-prompt-face now inherits magik-class-face

No behavior change beyond the face styling now coming from Magik-specific faces instead of generic font-lock faces.