### PR TITLE
Fix outline-regexp escaping bugs

### DIFF
--- a/magik-mode.el
+++ b/magik-mode.el
@@ -111,7 +111,7 @@ concrete implementations."
                imenu-generic-expression imenu-generic-expression
                imenu-create-index-function 'magik-imenu-create-index-function
                imenu-syntax-alist '((?_ . "w"))
-               outline-regexp "\\(^\\(_abstract +\\|\\)\\(_private +\\|\\)\\(_iter +\\|\\)_method.*\\|.*\.\\(def_property\\|add_child\\)\\|.*\.define_\\(shared_variable\\|shared_constant\\|slot_access\\|slot_externally_\\(read\\|writ\\)able\\|property\\|interface\\|method_signature\\).*\\|^\\(\t*#+\>[^>]\\|def_\\(slotted\\|indexed\\)_exemplar\\|def_mixin\\|#% text_encoding\\|_global\\|read_\\(message\\|translator\\)_patch\\).*\\)")
+               outline-regexp "\\(^\\(_abstract +\\|\\)\\(_private +\\|\\)\\(_iter +\\|\\)_method.*\\|.*\\.\\(def_property\\|add_child\\)\\|.*\\.define_\\(shared_variable\\|shared_constant\\|slot_access\\|slot_externally_\\(read\\|writ\\)able\\|property\\|interface\\|method_signature\\).*\\|^\\(\t*#+>+\\|def_\\(slotted\\|indexed\\)_exemplar\\|def_mixin\\|#%\\s-*text_encoding\\|_global\\|read_\\(message\\|translator\\)_patch\\).*\\)")
 
   (when magik-auto-abbrevs
     (abbrev-mode t)

--- a/test/magik-mode-test.el
+++ b/test/magik-mode-test.el
@@ -227,5 +227,168 @@
       (goto-char (point-min))
       (should-not (eq (get-text-property (point) 'face) 'magik-text-encoding-face)))))
 
+;;; outline-regexp
+
+(ert-deftest magik-outline-regexp--matches-with-space ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p outline-regexp "#% text_encoding = iso8859_1"))))
+
+(ert-deftest magik-outline-regexp--matches-without-space ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p outline-regexp "#%text_encoding=utf8"))))
+
+;; _method variants
+
+(ert-deftest magik-outline-regexp--matches-method-definition ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p outline-regexp "_method foo.bar()"))))
+
+(ert-deftest magik-outline-regexp--matches-plain-method ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p outline-regexp "_method some_engine.some_method_name()"))))
+
+(ert-deftest magik-outline-regexp--matches-private-method ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p outline-regexp "_private _method my_exemplar.some_slot"))))
+
+(ert-deftest magik-outline-regexp--matches-abstract-private-iter-method ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p outline-regexp "_abstract _private _iter _method foo.bar()"))))
+
+;; .def_property / .add_child
+
+(ert-deftest magik-outline-regexp--matches-def-property ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p outline-regexp "my_exemplar.def_property( :foo, :bar )"))))
+
+(ert-deftest magik-outline-regexp--matches-add-child ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p outline-regexp "a_tree.add_child( a_child )"))))
+
+;; .define_* variants
+
+(ert-deftest magik-outline-regexp--matches-define-shared-variable ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p
+             outline-regexp
+             "my_dialog.define_shared_variable(:active?,  _true, :public)"))))
+
+(ert-deftest magik-outline-regexp--matches-define-shared-constant ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p
+             outline-regexp
+             "my_dialog.define_shared_constant( :help_id, 60560, :public )"))))
+
+(ert-deftest magik-outline-regexp--matches-define-slot-access ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p
+             outline-regexp
+             "my_exemplar.define_slot_access(:some_slot, :writable)"))))
+
+(ert-deftest magik-outline-regexp--matches-define-slot-externally-readable ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p
+             outline-regexp
+             "my_exemplar.define_slot_externally_readable(:some_slot)"))))
+
+(ert-deftest magik-outline-regexp--matches-define-slot-externally-writable ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p
+             outline-regexp
+             "my_exemplar.define_slot_externally_writable(:log?)"))))
+
+(ert-deftest magik-outline-regexp--matches-define-property ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p
+             outline-regexp
+             "my_exemplar.define_property( :some_property, _unset)"))))
+
+(ert-deftest magik-outline-regexp--matches-define-interface ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p
+             outline-regexp
+             "my_exemplar.define_interface(:exported_properties, _unset)"))))
+
+(ert-deftest magik-outline-regexp--matches-define-method-signature ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p
+             outline-regexp
+             "my_exemplar.define_method_signature( :some_method|()|, _unset)"))))
+
+;; def_slotted_exemplar / def_indexed_exemplar / def_mixin, _global,
+;; read_message_patch / read_translator_patch
+
+(ert-deftest magik-outline-regexp--matches-def-slotted-exemplar ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p
+             outline-regexp
+             "def_slotted_exemplar(:my_exemplar, {{:some_slot, _unset}}, {:some_mixin})"))))
+
+(ert-deftest magik-outline-regexp--matches-def-mixin ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p outline-regexp "def_mixin(:my_mixin)"))))
+
+(ert-deftest magik-outline-regexp--matches-global ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p outline-regexp "_global my_global << _proc @my_global( some_arg )"))))
+
+(ert-deftest magik-outline-regexp--matches-read-message-patch ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p outline-regexp "read_message_patch(:my_application)"))))
+
+;; "#>" doc-comment heading markers.  A single "#" plus one or more ">"
+;; denotes increasingly nested heading levels, mirroring the "*", "**",
+;; "***" convention of Outline mode.
+
+(ert-deftest magik-outline-regexp--matches-single-level-doc-marker ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p outline-regexp "#> Heading"))))
+
+(ert-deftest magik-outline-regexp--matches-double-gt-doc-marker ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p outline-regexp "#>> _self.some_method()"))))
+
+(ert-deftest magik-outline-regexp--matches-double-hash-double-gt-doc-marker ()
+  (with-temp-buffer
+    (magik-mode)
+    (should (string-match-p outline-regexp "##>> _self.some_other_method(arg,"))))
+
+;; Negative cases
+
+(ert-deftest magik-outline-regexp--does-not-match-plain-code ()
+  (with-temp-buffer
+    (magik-mode)
+    (should-not (string-match-p outline-regexp "a << b + c"))))
+
+(ert-deftest magik-outline-regexp--define-branch-dot-is-a-literal-dot ()
+  "The \".*\\.\" before \"def_property\"/\"define_*\" must require a real
+literal \".\" separator, not match on an arbitrary character in its place."
+  (with-temp-buffer
+    (magik-mode)
+    (should-not (string-match-p outline-regexp "obj?def_property(:foo)"))
+    (should (string-match-p outline-regexp "obj.def_property(:foo)"))))
+
 (provide 'magik-mode-test)
 ;;; magik-mode-test.el ends here


### PR DESCRIPTION
outline-regexp in magik-mode had three regex-escaping bugs:

- The dot before def_property/add_child and the define_* variants was an unescaped "." (matches any character), so it accidentally matched things like "obj?def_property(...)". It is now a literal "\." requiring a real dot separator.
- The doc-comment heading marker (#>, #>>, ##>>, ...) required the ">" run to be followed by exactly one non-">" character, which breaks on a marker immediately followed by more ">"s or by end-of-match. Changed to ">+" to correctly match one or more nesting levels.
- The "#% text_encoding" marker only matched a literal single space, so "#%text_encoding=..." (also a valid form) was missed. Changed to "#%\s-*text_encoding" to match zero or more whitespace.

Also adds a new ERT test suite exercising outline-regexp against every branch of the regex: method definitions (plain/private/abstract/iter), .def_property/.add_child, all the .define_* variants, def_slotted_exemplar/def_mixin/_global/read_message_patch, the doc-comment markers, and negative cases covering the fixes above (plain code should not match; "obj?def_property" should not match but "obj.def_property" should).