### PR TITLE
Remove unused lexical variables in magik-mode.el

### DIFF
--- a/magik-mode.el
+++ b/magik-mode.el
@@ -1714,12 +1714,10 @@ Argument END ..."
 (defun magik-parse-pragma ()
   "Helper function for inserting pragma."
   (let ((ending-point (line-number-at-pos))
-        (starting-point 0)
         (search-result nil))
     (save-excursion
       (search-backward-regexp "^\\$" nil t)
-      (setq starting-point (line-number-at-pos)
-            search-result (search-forward-regexp (cdr (assoc "pragma" magik-regexp)) nil t))
+      (setq search-result (search-forward-regexp (cdr (assoc "pragma" magik-regexp)) nil t))
       (when (or (and (not (equal search-result nil))
                      (< ending-point (line-number-at-pos)))
                 (equal search-result nil))
@@ -1774,7 +1772,7 @@ This function is modified from `imenu--generic-function' to basically
 provide extra control over the name that appears in the index."
 
   (let ((index-alist (list 'dummy))
-        prev-pos beg
+        beg
         (case-fold-search imenu-case-fold-search)
         (old-table (syntax-table))
         (table (copy-syntax-table (syntax-table)))


### PR DESCRIPTION
## Summary

A code review of #149 (the lexical-binding-enabling PR) surfaced two pre-existing dead-code spots in `magik-mode.el` that already exist on `master` today, unrelated to that PR's actual change. They were only newly visible because lexical-binding's stricter compiler diagnostics flag unused lexical variables that dynamic binding silently didn't warn about.

- `magik-parse-pragma`: `starting-point` was assigned from `(line-number-at-pos)` right after `search-backward-regexp`, but never read anywhere afterward. Checked the full git history of the function (it was introduced whole in af1b837 and never modified since); `starting-point` has never been used since the function was first written, so this is genuinely dead code, not a dropped bounds check. The `search-backward-regexp` call itself is kept, since it still matters for its side effect of repositioning point before the subsequent `search-forward-regexp`.
- `magik-imenu-create-index-function`: `prev-pos` was bound in the top-level `let` but never referenced in the body. The function is documented as "modified from `imenu--generic-function`", which likely used a variable like this to avoid duplicate menu entries; this adapted version already guards against duplicates a different way (`(unless (member item (cdr menu)) ...)`), making `prev-pos` vestigial here.

## Verification

- `check-parens` passes.
- Byte-compiling with a temporary `lexical-binding: t` cookie added confirms the two targeted "Unused lexical variable" warnings are present before this change and gone after, with no new warnings introduced.
- Full test suite (`eask run script test`) passes with identical counts before and after: 268 tests, 257 as expected, 0 unexpected, 11 skipped.

## Test plan

- [x] `check-parens` on `magik-mode.el`
- [x] Byte-compile comparison (before/after, with temporary lexical-binding cookie) confirms the targeted warnings disappear and no new ones appear
- [x] `eask install-deps && eask package && eask install && eask run script test` matches baseline pass/skip counts with zero new failures