### PR TITLE
[bug-fix] completion snippets not completing params with ?

### DIFF
--- a/magik-completion.el
+++ b/magik-completion.el
@@ -876,10 +876,9 @@ Returns a list (REQUIRED OPTIONAL GATHER)."
            ((looking-at "OPT ")
             (setq opt t)
             (goto-char (match-end 0)))
-           ((> (skip-syntax-forward "w_") 0)
-            (let ((name (buffer-substring-no-properties
-                         (save-excursion (skip-syntax-backward "w_") (point))
-                         (point))))
+           ((looking-at "[[:alnum:]_?!]+")
+            (let ((name (match-string-no-properties 0)))
+              (goto-char (match-end 0))
               (if opt
                   (push name optional)
                 (push name args)))

--- a/test/magik-completion-test.el
+++ b/test/magik-completion-test.el
@@ -205,6 +205,26 @@ Returns (ARGS OPTIONAL GATHER)."
   (should (equal (magik-completion-test--parse-args "thing iter_method OPT GATH args")
                  '(("thing" "iter_method") nil ("args")))))
 
+(ert-deftest magik-completion--parse-args-line--question-mark-suffixed-names ()
+  "Required param names ending in `?' must be kept whole, not truncated."
+  (should (equal (magik-completion-test--parse-args "yes? no?")
+                 '(("yes?" "no?") nil nil))))
+
+(ert-deftest magik-completion--parse-args-line--bang-suffixed-optional-name ()
+  "Optional param names ending in `!' must be kept whole, not truncated."
+  (should (equal (magik-completion-test--parse-args "OPT flag!")
+                 '(nil ("flag!") nil))))
+
+(ert-deftest magik-completion--parse-args-line--question-mark-names-without-cb-mode ()
+  "Parsing must not depend on `magik-cb-mode' syntax table being active.
+The real CB completion process buffer is created in `fundamental-mode'
+\(see `magik-completion--ensure-cb-process'), where `?' and `!' are not
+word-syntax characters, so the parser must not rely on `skip-syntax-forward'."
+  (with-temp-buffer
+    (insert " yes? no?\n")
+    (should (equal (magik-completion--parse-args-line (point-min))
+                   '(("yes?" "no?") nil nil)))))
+
 (ert-deftest magik-completion--parse-args-line--gather-no-trailing-newlines ()
   "Gather param name must not include trailing newlines from the CB buffer."
   (with-temp-buffer


### PR DESCRIPTION
`magik-completion--parse-args-line` scanned parameter names with
`skip-syntax-forward "w_"`, which doesn't include `?`/`!`, so names like
`yes?` were truncated to `yes`. Replaced the syntax-based scan with a
regexp matching `[[:alnum:]_?!]+` so full parameter names are captured.
