### PR TITLE
Allow slot completion with an empty prefix right after the dot

### DIFF
--- a/magik-completion.el
+++ b/magik-completion.el
@@ -408,7 +408,8 @@ Returns nil if point is inside a comment or string."
           (cons beg end))))))
 
 (defun magik-completion--slot-bounds ()
-  "Return bounds if point is completing a slot reference (after `.')."
+  "Return bounds if point is completing a slot reference (after `.').
+Allows an empty prefix (BEG == END) right after the dot."
   (let ((syntax (syntax-ppss)))
     (when (and (magik-completion--available-p)
                (not (nth 3 syntax))
@@ -417,8 +418,7 @@ Returns nil if point is inside a comment or string."
             (beg (save-excursion
                    (skip-chars-backward "a-zA-Z0-9_!?")
                    (point))))
-        (when (and (< beg end)
-                   (> beg (point-min))
+        (when (and (> beg (point-min))
                    (eq (char-before beg) ?.)
                    ;; slot access: preceding char before . is not a word char
                    ;; (i.e. it's `.slot` not `obj.method`)
@@ -484,6 +484,7 @@ so code inspecting properties at position 0 (e.g. `magik-package',
               (slots (magik-completion--scan-slots)))
     (list (car bounds) (cdr bounds) slots
           :exclusive 'no
+          :company-prefix-length t
           :company-kind (lambda (_) 'property)
           :annotation-function (magik-completion--kind-annotation 'slot))))
 

--- a/test/magik-completion-test.el
+++ b/test/magik-completion-test.el
@@ -323,6 +323,46 @@ $
     (should-not (magik-completion--exemplar-definition-region ""))
     (should-not (magik-completion--exemplar-definition-region nil))))
 
+;;; Slot bounds detection
+
+(ert-deftest magik-completion--slot-bounds--bare-dot-offers-empty-prefix ()
+  "A bare `.' with no receiver offers the full slot list immediately."
+  (with-temp-buffer
+    (insert magik-completion-test--two-exemplars)
+    (goto-char (point-min))
+    (search-forward "_return .")
+    (should (equal (magik-completion--slot-bounds) (cons (point) (point))))))
+
+(ert-deftest magik-completion--slot-bounds--narrows-to-typed-prefix ()
+  "Typing \".s\" after a bare dot still bounds just the \"s\" prefix."
+  (with-temp-buffer
+    (insert magik-completion-test--two-exemplars)
+    (goto-char (point-min))
+    (search-forward "_return .")
+    (insert "s")
+    (should (equal (magik-completion--slot-bounds) (cons (1- (point)) (point))))))
+
+(ert-deftest magik-completion--slot-bounds--receiver-before-dot-offers-nothing ()
+  "A `.' preceded by a receiver is method access, not slot access."
+  (with-temp-buffer
+    (magik-mode)
+    (insert "pseudo_area.")
+    (should-not (magik-completion--slot-bounds))))
+
+(ert-deftest magik-completion-at-point-slots--bare-dot-sets-company-prefix-length ()
+  "Marks the result as satisfying any frontend minimum-prefix-length."
+  (with-temp-buffer
+    (insert magik-completion-test--two-exemplars)
+    (goto-char (point-min))
+    (search-forward "_return .")
+    (let ((capf (magik-completion-at-point-slots)))
+      (should capf)
+      (should (equal (list (nth 0 capf) (nth 1 capf)) (list (point) (point))))
+      (should (member "owner" (nth 2 capf)))
+      (should (member "size" (nth 2 capf)))
+      (should-not (member "other_slot" (nth 2 capf)))
+      (should (eq (plist-get (nthcdr 3 capf) :company-prefix-length) t)))))
+
 ;;; Package-qualified completion
 
 (ert-deftest magik-completion--typed-package--qualified-prefix ()


### PR DESCRIPTION
magik-completion--slot-bounds required at least one typed character after the dot, so `.slot_name`-style bare-dot slot access (e.g. a lone `.` inside a method body) offered no completions. Drop that guard so the full slot list is available immediately, and mark the CAPF result with :company-prefix-length t so corfu/company auto-pop it without needing a lower minimum-prefix-length setting.