### PR TITLE
[magik-completion] fix slot-detection without exemplar reference

### DIFF
--- a/magik-completion.el
+++ b/magik-completion.el
@@ -356,19 +356,20 @@ EXEMPLAR is nil, empty, or not defined in this buffer."
 (defun magik-completion--scan-slots ()
   "Scan for slot names of the exemplar the method at point belongs to.
 Slots are read from the matching exemplar definition when it can be
-found in the buffer; otherwise the whole buffer is scanned.
-Returns a list of slot name strings."
+found in the buffer; otherwise no slots are returned.  Returns a list
+of slot name strings."
   (let* ((exemplar (when (fboundp 'magik-current-method-name)
                      (cadr (magik-current-method-name))))
          (region (magik-completion--exemplar-definition-region exemplar))
          (slots '()))
-    (save-excursion
-      (goto-char (or (car region) (point-min)))
-      (while (re-search-forward
-              "{\\s-*:\\([a-z_][a-z0-9_!?]*\\)\\s-*," (cdr region) t)
-        (let ((slot (match-string-no-properties 1)))
-          (unless (member slot slots)
-            (push slot slots)))))
+    (when region
+      (save-excursion
+        (goto-char (car region))
+        (while (re-search-forward
+                "{\\s-*:\\([a-z_][a-z0-9_!?]*\\)\\s-*," (cdr region) t)
+          (let ((slot (match-string-no-properties 1)))
+            (unless (member slot slots)
+              (push slot slots))))))
     (nreverse slots)))
 
 ;;; --- Prefix detection ---

--- a/test/magik-completion-test.el
+++ b/test/magik-completion-test.el
@@ -308,12 +308,21 @@ $
       (should (member "size" slots))
       (should-not (member "other_slot" slots)))))
 
-(ert-deftest magik-completion--scan-slots--falls-back-to-whole-buffer ()
-  "Outside any method the whole buffer is scanned."
+(ert-deftest magik-completion--scan-slots--unresolved-exemplar-returns-nothing ()
+  "When the current exemplar can't be resolved, no slots are offered,
+even when the buffer contains a `def_slotted_exemplar' form and other
+text that merely looks like a slot pair (e.g. a `property_list.new_with'
+call), as in the case that motivated this test."
   (with-temp-buffer
-    (insert "def_slotted_exemplar(:a_thing,\n\t{\n\t\t{:a_slot, _unset}\n\t})\n$\n")
+    (insert "def_slotted_exemplar(:my_test_env,\n\t{\n\t\t{:niet_aap, _unset}\n\t})\n$\n\n"
+            "my_test_env.define_shared_constant(:example,\n"
+            "    property_list.new_with(\n"
+            "\t:example, {:first_mode, :second_mode},\n"
+            "\t:example_2, {:third_mode, :fourth_mode}\n"
+            "    ),\n"
+            "    :private)\n$\n")
     (goto-char (point-max))
-    (should (member "a_slot" (magik-completion--scan-slots)))))
+    (should-not (magik-completion--scan-slots))))
 
 (ert-deftest magik-completion--exemplar-definition-region--not-found ()
   "Unknown or empty exemplar names yield no region."


### PR DESCRIPTION
<img width="443" height="465" alt="image" src="https://github.com/user-attachments/assets/8bef887f-f608-49ff-ade5-7788580d0056" />

When no exemplar can be deduced (for example in a block)
Should just not return anything